### PR TITLE
Speed up all benchmarks

### DIFF
--- a/src/benchmarks/cartographer_ros_benchmark/scripts/magazino_benchmark.robot
+++ b/src/benchmarks/cartographer_ros_benchmark/scripts/magazino_benchmark.robot
@@ -27,7 +27,7 @@ Hallway Return           hallway_return.bag
 Benchmark Cartographer ROS 2D SLAM
     [Arguments]  ${dataset}
     Register Parameters  dataset=${dataset}
-    Use 2 minutes of all data in ${dataset} as input
+    Use 2 minutes of all data in ${dataset} at 5x as input
     Track /tf:odom.base_link /tf:map.base_link trajectories
     And save the resulting map
     Use magazino_benchmark.launch in cartographer_ros_benchmark package to launch

--- a/src/benchmarks/cartographer_ros_benchmark/scripts/mars_benchmark.robot
+++ b/src/benchmarks/cartographer_ros_benchmark/scripts/mars_benchmark.robot
@@ -14,7 +14,7 @@ Indoor Loop              MARS_Loop_1.bag MARS_Loop_2.bag MARS_Loop_3.bag
 Benchmark Cartographer ROS 2D SLAM
     [Arguments]  ${dataset}
     Register Parameters  dataset=${dataset}
-    Use /tf /vertical_velodyne/velodyne_points /odometry/filtered data in ${dataset} as input
+    Use /tf /vertical_velodyne/velodyne_points /odometry/filtered data in ${dataset} at 5x as input
     Track /tf:odom.base_link /tf:map.base_link trajectories
     And save the resulting map
     Use mars_benchmark.launch in cartographer_ros_benchmark package to launch

--- a/src/benchmarks/cartographer_ros_benchmark/scripts/rawseeds_benchmark.robot
+++ b/src/benchmarks/cartographer_ros_benchmark/scripts/rawseeds_benchmark.robot
@@ -27,7 +27,7 @@ Indoors with static illumination      Bicocca_2009-02-25b_Static_Lamps.bag
 Benchmark Cartographer ROS 2D SLAM
     [Arguments]  ${dataset}
     Register Parameters  dataset=${dataset}
-    Use 2 minutes of /tf /odom /scan/front /scan/rear data in ${dataset} as input
+    Use 2 minutes of /tf /odom /scan/front /scan/rear data in ${dataset} at 5x as input
     Track /tf:map.base_link /tf:odom.base_link trajectories
     And save the resulting map
     Use rawseeds_benchmark.launch in cartographer_ros_benchmark package to launch

--- a/src/benchmarks/cartographer_ros_benchmark/scripts/tum_benchmark.robot
+++ b/src/benchmarks/cartographer_ros_benchmark/scripts/tum_benchmark.robot
@@ -30,7 +30,7 @@ Freiburg2 Pioneer SLAM 3   rgbd_dataset_freiburg2_pioneer_slam3.bag
 Benchmark Cartographer ROS 2D SLAM
     [Arguments]  ${dataset}
     Register Parameters  dataset=${dataset}
-    Use /tf /scan /pose data in ${dataset} as input
+    Use /tf /scan /pose data in ${dataset} at 5x as input
     Track /tf:world.kinect /tf:map.base_link trajectories
     And save the resulting map
     Use tum_benchmark.launch in cartographer_ros_benchmark package to launch

--- a/src/benchmarks/slam_toolbox_benchmark/scripts/mars_benchmark.robot
+++ b/src/benchmarks/slam_toolbox_benchmark/scripts/mars_benchmark.robot
@@ -27,7 +27,7 @@ Indoor loop              MARS_Loop_1.bag MARS_Loop_2.bag MARS_Loop_3.bag
 Benchmark SLAM Toolbox 2D SLAM
     [Arguments]  ${dataset}
     Register Parameters  dataset=${dataset}
-    Use /tf /vertical_velodyne/velodyne_points data in ${dataset} as input
+    Use /tf /vertical_velodyne/velodyne_points data in ${dataset} at 10x as input
     Track /tf:odom.base_link /tf:map.base_link trajectories
     And save the resulting map
     Use mars_benchmark.launch in slam_toolbox_benchmark package to launch

--- a/src/benchmarks/slam_toolbox_benchmark/scripts/parametric_benchmark.robot
+++ b/src/benchmarks/slam_toolbox_benchmark/scripts/parametric_benchmark.robot
@@ -34,7 +34,7 @@ Benchmark SLAM Toolbox 2D SLAM
     ...  dataset=${dataset}
     ...  resolution=${resolution}
     ...  search_resolution=${search_resolution}
-    Use /tf /scan data in ${dataset} as input
+    Use /tf /scan data in ${dataset} at 10x as input
     Track /tf:world.kinect /tf:map.base_link trajectories
     And save the resulting map
     Use parametric_benchmark.launch in slam_toolbox_benchmark package to launch

--- a/src/benchmarks/slam_toolbox_benchmark/scripts/rawseeds_benchmark.robot
+++ b/src/benchmarks/slam_toolbox_benchmark/scripts/rawseeds_benchmark.robot
@@ -27,7 +27,7 @@ Indoors with static illumination      Bicocca_2009-02-25b_Static_Lamps.bag
 Benchmark SLAM Toolbox 2D SLAM
     [Arguments]  ${dataset}
     Register Parameters  dataset=${dataset}
-    Use 2 minutes of /tf /odom /scan/front /scan/rear data in ${dataset} as input
+    Use 2 minutes of /tf /odom /scan/front /scan/rear data in ${dataset} at 10x as input
     Track /tf:map.base_link /tf:odom.base_link trajectories
     And save the resulting map
     Use rawseeds_benchmark.launch in slam_toolbox_benchmark package to launch

--- a/src/benchmarks/slam_toolbox_benchmark/scripts/tum_benchmark.robot
+++ b/src/benchmarks/slam_toolbox_benchmark/scripts/tum_benchmark.robot
@@ -30,7 +30,7 @@ Freiburg2 Pioneer SLAM 3   rgbd_dataset_freiburg2_pioneer_slam3.bag
 Benchmark SLAM Toolbox 2D SLAM
     [Arguments]  ${dataset}
     Register Parameters  dataset=${dataset}
-    Use /tf /scan data in ${dataset} as input
+    Use /tf /scan data in ${dataset} at 10x as input
     Track /tf:world.kinect /tf:map.base_link trajectories
     And save the resulting map
     Use tum_benchmark.launch in slam_toolbox_benchmark package to launch

--- a/src/core/lambkin/src/lambkin.resource
+++ b/src/core/lambkin/src/lambkin.resource
@@ -89,7 +89,7 @@ Play ROS Bags
         File Should Exist  ${bag}
         # TODO(nahuel): warning if ROS bag is compressed
     END
-    @{options} =  Create List  --quiet  --clock
+    @{options} =  Create List  --quiet  --clock  --wait-for-subscribers
     IF  '${topics}' != '${null}' and '${topics}' != 'all'
         @{topics} =  Split String  ${topics}
         Append To List  ${options}  --topics  @{topics}
@@ -104,6 +104,8 @@ Play ROS Bags
     END
     IF  '${rate}' != '${null}'
         Append To List  ${options}  --rate  ${rate}
+        ${clock_rate} =  Evaluate  $rate * 10
+        Append To List  ${options}  --hz  ${clock_rate}
     END
     Run Process  rosbag  play  @{bags}  @{options}
     ...          stdout=DEVNULL  stderr=DEVNULL  &{kwargs}


### PR DESCRIPTION
### Proposed changes

Closes #21. This patch tweaks bagfile playback settings to allow for faster benchmarks. 

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [ ] ~Lint and unit tests (if any) pass locally with my changes~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added necessary documentation (if appropriate)~

### Additional comments

The change is not innocuous: both Cartographer ROS and SLAM Toolbox struggle as the playback rate is increased. Clock distribution latency is a problem (as it has always been in ROS). For this particular patch, I've empirically increased playback rates for all benchmarks enough for it to be worthwhile. I have not tried to push the limits (yet). 