### PR TITLE
POC: Use ansible-bender to build docker image.

### DIFF
--- a/.ansible/playbooks/slam_toolbox_benchmarks.yml
+++ b/.ansible/playbooks/slam_toolbox_benchmarks.yml
@@ -1,0 +1,29 @@
+---
+- name: Setup a slam toolbox benchmarks
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_bender:
+      base_image: "docker.io/osrf/ros:noetic-desktop-full-focal"
+
+      working_container:
+        volumes:
+          # TODO: Find a way to replace it
+          - "/home/erasmo/Projects/lambkin/src/benchmarks/slam_toolbox_benchmarks:/tmp/ws/src/package"
+
+      target_image:
+        name: ekumenlabs/slam-toolbox-benchmarks:latest
+
+  tasks:
+    - name: Install ros-noetic-pointcloud-to-laserscan
+      ansible.builtin.apt:
+        name: ros-noetic-pointcloud-to-laserscan
+        state: present
+
+    - name: Run rosdep install
+      ansible.builtin.command: "rosdep install -i -y --from-path src --skip-keys 'lambkin-shepherd'"
+      args:
+        chdir: /tmp/ws
+
+    - name: Remove APT lists
+      ansible.builtin.command: sudo rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Ansible-bender to build the docker image.

This is a proof of concept (POC) that exposes a way to create docker images using [Ansible-bender](https://ansible-community.github.io/ansible-bender/build/html/index.html). Currently, the images are being created using various tools, including `docker` and `docker-bake`. It is reported that this is not using the cache properly and hinders the development process. This occurs because the Dockerfiles use Ansible to install tools in the image being built, this has the particularity that it does not generate a final state that allows Docker to know if it needs to execute that step again, making it necessary to execute that step always. [Reference](https://github.com/ekumenlabs/lambkin/blob/9e1c854f6a5b31e7305ff9a97f5c45bb528defe7/Dockerfile#L71). 

Ansible-bender takes an Ansible playbook and runs the tasks in container layers and creates a final image, the advantage is the caching system used by this tool. Each task is not run again unless you change the task definition. We could translate our Dockerfiles into Ansible tasks and use Ansible-bender to build the docker image instead of using `docker` and `docker-bake` as I did in `slam_toolbox_benchmarks.yml` or create [Ansible roles](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html) to define certain collection of task/benchmark and use inside any playbook. 

Take `slam_toolbox_benchmarks` as an example to demonstrate how ansible-bender works.

**Which tool does Ansible-bender need to run ?**
- **Podman** https://podman.io/
- **Buildah** https://github.com/containers/buildah

**How could the maintainer reproduce this POC?**
- First need to install `ansible-bender` on their local machine using this tutorial https://ansible-community.github.io/ansible-bender/build/html/installation.html in the same tutorial there is a link to install `buildah` and `podman`.
- Second checkout to the branch `63-lambkin-base-image-doesnt-cache-properly`
- Third replace line 12 inside `.ansible/playbook/slam_toolbox_benchmarks.yml` with their absolute path.
- Fourth run the next command `ansible-bender build .ansible/playbooks/slam_toolbox_benchmarks.yml -e "repository_uri=file:///tmp/contex" exclude_components=lambkin-shephe`.

You will notice that the first run takes a while to execute all the steps, however, if you run the command again you will be able to notice the reduction because `ansible-bender` user their cache system to skip tasks.

**First run**
```
PLAY [Setup a slam toolbox benchmarks] *****************************************

TASK [Gathering Facts] *********************************************************
ok: [ekumenlabs-slam-toolbox-benchmarks-latest-20230915-165750465920-cont]

TASK [Install ros-noetic-pointcloud-to-laserscan] ******************************
changed: [ekumenlabs-slam-toolbox-benchmarks-latest-20230915-165750465920-cont]

TASK [Run rosdep install] ******************************************************
changed: [ekumenlabs-slam-toolbox-benchmarks-latest-20230915-165750465920-cont]

TASK [Remove APT lists] ********************************************************
changed: [ekumenlabs-slam-toolbox-benchmarks-latest-20230915-165750465920-cont]

PLAY RECAP *********************************************************************
ekumenlabs-slam-toolbox-benchmarks-latest-20230915-165750465920-cont : ok=4    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

Getting image source signatures
Copying blob sha256:954c82bdeb5fcc80094317528fa3fcbb1026aeff64f872527d35ec9b4343b84d
Copying blob sha256:4b0512d9d310cf2392a9fcd3be3551bd0b1d07b5713254d561941dcc14fb4b07
Copying blob sha256:5b9396c1e9eac9d0c0b55aeaa053473938194fc750735cf785feca1ddf69ce1b
Copying blob sha256:66dbd19557def88305773f0753b63395555f9276c8ae8193c425f8907553b450
Copying blob sha256:075a5af4100bf88e1df0bc881365d3586b02edf0401aeb84adad43e513edd5aa
Copying blob sha256:ff5f55dfdd77d103a66b926c6d6e4142c082da01c3b83c57393ec29546522bda
Copying blob sha256:5525f95c758621921fc2b5d94d07f7df3ce4442e60232b6cf3051d917b7716c8
Copying blob sha256:5016d5c2ea200e75fb875312a87d26fa68d4c203368be172f4aebceec946dca8
Copying blob sha256:1e824ec36dab8d1224831890027e4b2def9495803fd9a5c77143d96d9533863a
Copying blob sha256:b3e6d1a4113a0cbe94aa1ee5ce172e6fbf25d829ce053de443b7290e6e75579d
Copying blob sha256:805ead73da8d152c2ed79e8ec5c3831e267504134b766ffe2f065ad5e44a9dbc
Copying blob sha256:a4ee71ab05217e8e42ee9fefc3fbd9770562ec5179d79e88df19263e940cd41f
Copying blob sha256:54af132bb0450e0ed5b24d6f1243ee6e207d61e7dafe1648b9f677fb2738a93b
Copying blob sha256:f2b8c0693c6fc9e806e40f3287e684b4f3897c24bb2473a5c0be51ae037272a3
Copying config sha256:4f34c21c0d6990630b79b663b60b3b5506ccecbd1cb51851317af1de6844075d
Writing manifest to image destination
Storing signatures
4f34c21c0d6990630b79b663b60b3b5506ccecbd1cb51851317af1de6844075d
Image 'ekumenlabs/slam-toolbox-benchmarks:latest' was built successfully \o/
```

**Second run**
```
PLAY [Setup a slam toolbox benchmarks] *****************************************

TASK [Gathering Facts] *********************************************************
ok: [ekumenlabs-slam-toolbox-benchmarks-latest-20230915-170024270415-cont]

TASK [Install ros-noetic-pointcloud-to-laserscan] ******************************
loaded from cache: 'sha256:4885d4165cf7b097e072bbbb77a0f90d0fb26b4c936d0fb0e1996a19fd8e90f1'
skipping: [ekumenlabs-slam-toolbox-benchmarks-latest-20230915-170024270415-cont]

TASK [Run rosdep install] ******************************************************
loaded from cache: 'sha256:c70b2520d6c75e00a8698fe9b4eca0740df882d8bbe4777f8464006dd73d2376'
skipping: [ekumenlabs-slam-toolbox-benchmarks-latest-20230915-170024270415-cont]

TASK [Remove APT lists] ********************************************************
loaded from cache: 'sha256:e3537e1ef404e7343c427409a9f306ebc2251b31967e4452a6cdc663447371d9'
skipping: [ekumenlabs-slam-toolbox-benchmarks-latest-20230915-170024270415-cont]

PLAY RECAP *********************************************************************
ekumenlabs-slam-toolbox-benchmarks-latest-20230915-170024270415-cont : ok=1    changed=0    unreachable=0    failed=0    skipped=3    rescued=0    ignored=0   

Getting image source signatures
Copying blob sha256:954c82bdeb5fcc80094317528fa3fcbb1026aeff64f872527d35ec9b4343b84d
Copying blob sha256:4b0512d9d310cf2392a9fcd3be3551bd0b1d07b5713254d561941dcc14fb4b07
Copying blob sha256:5b9396c1e9eac9d0c0b55aeaa053473938194fc750735cf785feca1ddf69ce1b
Copying blob sha256:66dbd19557def88305773f0753b63395555f9276c8ae8193c425f8907553b450
Copying blob sha256:075a5af4100bf88e1df0bc881365d3586b02edf0401aeb84adad43e513edd5aa
Copying blob sha256:ff5f55dfdd77d103a66b926c6d6e4142c082da01c3b83c57393ec29546522bda
Copying blob sha256:5525f95c758621921fc2b5d94d07f7df3ce4442e60232b6cf3051d917b7716c8
Copying blob sha256:5016d5c2ea200e75fb875312a87d26fa68d4c203368be172f4aebceec946dca8
Copying blob sha256:1e824ec36dab8d1224831890027e4b2def9495803fd9a5c77143d96d9533863a
Copying blob sha256:b3e6d1a4113a0cbe94aa1ee5ce172e6fbf25d829ce053de443b7290e6e75579d
Copying blob sha256:805ead73da8d152c2ed79e8ec5c3831e267504134b766ffe2f065ad5e44a9dbc
Copying blob sha256:a4ee71ab05217e8e42ee9fefc3fbd9770562ec5179d79e88df19263e940cd41f
Copying blob sha256:54af132bb0450e0ed5b24d6f1243ee6e207d61e7dafe1648b9f677fb2738a93b
Copying blob sha256:f2b8c0693c6fc9e806e40f3287e684b4f3897c24bb2473a5c0be51ae037272a3
Copying blob sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef
Copying config sha256:5e25f579086b8344d44aa1967aaf3ed609c554ad6e3ca1ace7565fee6e804eb3
Writing manifest to image destination
Storing signatures
5e25f579086b8344d44aa1967aaf3ed609c554ad6e3ca1ace7565fee6e804eb3
Image 'ekumenlabs/slam-toolbox-benchmarks:latest' was built successfully \o/
```

**How could the maintainer confirm the image works as we spect ?**
Following the next commands:
1. `podman run -it localhost/ekumenlabs/slam-toolbox-benchmarks:latest bash` will run a container using the image built by ansible-bender
2. `sudo apt-cache policy catkin` should confirm if the package was installed.

These steps confirm that the image was created successfully and that the necessary packages from that package were installed, which is the same as what is currently doing docker and docker-bake.

**Considerations**
- The images are created in Podman, which will require defining a process to make the images available in the local docker register of the machine that executes the command.
- Currently, base images are created and other dependencies are installed on top of them. These images must be converted to roles and subsequently used as dependencies. This is outside the scope of this POC.

#### Type of change

- [X] 🐛 Bugfix #63 

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)