### PR TITLE
Allow trajectory groundtruth from files

### DIFF
--- a/src/core/lambkin-shepherd/src/lambkin/shepherd/robot/api/evo.py
+++ b/src/core/lambkin-shepherd/src/lambkin/shepherd/robot/api/evo.py
@@ -14,6 +14,8 @@
 
 """This module supplements RobotFramework ``evo`` library resource."""
 
+import os.path
+
 from robot.api.deco import keyword
 
 
@@ -27,3 +29,9 @@ def convert_to_evo_filestem(name: str, name_format: str) -> str:
     """
     from lambkin.shepherd.data.evo import _to_evo_filestem
     return _to_evo_filestem(name, name_format)
+
+
+@keyword('Infer Trajectory File Format')
+def infer_trajectory_file_format(path: str) -> str:
+    """Infer format for trajectory file at `path`."""
+    return os.path.splitext(path)[1].lstrip('.')

--- a/src/core/lambkin-shepherd/src/lambkin/shepherd/robot/resources/benchmarks/ros/slam.resource
+++ b/src/core/lambkin-shepherd/src/lambkin/shepherd/robot/resources/benchmarks/ros/slam.resource
@@ -64,34 +64,39 @@ After ROS 2D SLAM system benchmark case iteration
     ...                            ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
     ...                            Ground truth trajectory already tracked
 
-    ${result} =  Perform trajectory analysis  bag  ${BENCHMARK.OUTPUT.ROS.BAG}
-    ...                                       @{BENCHMARK.OUTPUT.SLAM.TRAJECTORIES}
-    ...                                       ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
-    ...                                       ref=${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
-    ...                                       ros_map_yaml=${BENCHMARK.OUTPUT.MAP.PATH}
-    ...                                       plot_mode=xy  save_plot=all.png
-    ...                                       no_warnings=yes  save_as_tum=yes
-    ...                                       &{BENCHMARK.OUTPUT.SLAM.CORRECTIONS}
-    ...                                       cwd=${BENCHMARK.CASE.ITERATION.PATH}
-    Should Be Equal  ${result.rc}  ${0}
-    Wait Until Created  ${BENCHMARK.CASE.ITERATION.PATH}/all_trajectories.png  timeout=10s
-    File Should Exist  ${BENCHMARK.CASE.ITERATION.PATH}/all_trajectories.png
+    ${result} =  Manipulate Trajectories  bag  ${BENCHMARK.OUTPUT.ROS.BAG}
+    ...                                   @{BENCHMARK.OUTPUT.SLAM.TRAJECTORIES}
+    ...                                   no_warnings=yes  save_as_tum=yes
+    ...                                   cwd=${BENCHMARK.CASE.ITERATION.PATH}
+    Should Be Equal  ${result.rc}  ${0}  msg=${result.stderr}
 
+    @{trajectories} =  Create List
     FOR  ${trajectory}  IN  @{BENCHMARK.OUTPUT.SLAM.TRAJECTORIES}
-        ${stem} =  Convert To EVO Filestem  ${trajectory}  name_format=ros
-        ${result} =  Estimate APE  bag  ${BENCHMARK.OUTPUT.ROS.BAG}
-        ...          ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}  ${trajectory}
-        ...          save_plot=${stem}.ape.png  save_results=${stem}.ape.zip
-        ...          plot_mode=xy  no_warnings=yes  &{BENCHMARK.OUTPUT.SLAM.CORRECTIONS}
-        ...          cwd=${BENCHMARK.CASE.ITERATION.PATH}
-        Should Be Equal  ${result.rc}  ${0}
-        Wait Until Created  ${BENCHMARK.CASE.ITERATION.PATH}/${stem}.ape.zip  timeout=10s
-        File Should Exist  ${BENCHMARK.CASE.ITERATION.PATH}/${stem}.ape.zip
-        ${result} =  Estimate RPE  bag  ${BENCHMARK.OUTPUT.ROS.BAG}  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
-        ...          ${trajectory}  save_plot=${stem}.rpe.png  save_results=${stem}.rpe.zip
-        ...          plot_mode=xy  no_warnings=yes  &{BENCHMARK.OUTPUT.SLAM.CORRECTIONS}
-        ...          cwd=${BENCHMARK.CASE.ITERATION.PATH}
-        Should Be Equal  ${result.rc}  ${0}
-        Wait Until Created  ${BENCHMARK.CASE.ITERATION.PATH}/${stem}.rpe.zip  10s
-        File Should Exist  ${BENCHMARK.CASE.ITERATION.PATH}/${stem}.rpe.zip
+        ${filestem} =  Convert To EVO Filestem  ${trajectory}  name_format=ros
+        Append To List  ${trajectories}  ${filestem}.tum
     END
+
+    IF  ${BENCHMARK.OUTPUT.SLAM.USE_GROUNDTRUTH_FROM_FILE}
+        ${groundtruth_format} =  Infer Trajectory File Format  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
+        IF  "${groundtruth_format}" != "tum"
+            ${result} =  Manipulate Trajectories
+            ...    ${groundtruth_format}  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
+            ...    no_warnings=yes  save_as_tum=yes  cwd=${BENCHMARK.CASE.ITERATION.PATH}
+            Should Be Equal  ${result.rc}  ${0}  msg=${result.stderr}
+            ${filestem} =  Convert To EVO Filestem  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}  name_format=path
+            ${groundtruth} =  Set Variable  ${filestem}.tum
+        ELSE
+            ${groundtruth} =  Set Variable  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
+        END
+    ELSE
+        ${result} =  Manipulate Trajectories
+        ...    bag  ${BENCHMARK.OUTPUT.ROS.BAG}  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
+        ...    no_warnings=yes  save_as_tum=yes  cwd=${BENCHMARK.CASE.ITERATION.PATH}
+        Should Be Equal  ${result.rc}  ${0}  msg=${result.stderr}
+        ${filestem} =  Convert To EVO Filestem  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}  name_format=ros
+        ${groundtruth} =  Set Variable  ${filestem}.tum
+    END
+
+    Perform TUM Trajectory Analysis
+    ...    @{trajectories}  ref=${groundtruth}  map=${BENCHMARK.OUTPUT.MAP.PATH}
+    ...    &{BENCHMARK.OUTPUT.SLAM.CORRECTIONS}  cwd=${BENCHMARK.CASE.ITERATION.PATH}

--- a/src/core/lambkin-shepherd/src/lambkin/shepherd/robot/resources/benchmarks/ros2/base.resource
+++ b/src/core/lambkin-shepherd/src/lambkin/shepherd/robot/resources/benchmarks/ros2/base.resource
@@ -188,6 +188,13 @@ For ROS 2 system benchmark case rig bringup
     ...  @{BENCHMARK.RIG.ROS.LAUNCH.ARGUMENTS}
     ...  package=${BENCHMARK.RIG.ROS.LAUNCH.PACKAGE}
 
+On ROS 2 system benchmark case rig bringup
+    [Documentation]
+    ...  See `On ${some} benchmark case rig bringup` documentation.
+    [Tags]  declarative  override
+    # NOTE(hidmic): wait for system to start
+    Sleep  1s
+
 After ROS 2 system benchmark case rig bringup
     [Documentation]
     ...  See `After ${some} benchmark case rig bringup` documentation.

--- a/src/core/lambkin-shepherd/src/lambkin/shepherd/robot/resources/benchmarks/ros2/slam.resource
+++ b/src/core/lambkin-shepherd/src/lambkin/shepherd/robot/resources/benchmarks/ros2/slam.resource
@@ -69,34 +69,39 @@ After ROS 2 2D SLAM system benchmark case iteration
     # - https://github.com/MichaelGrupp/evo/issues/443.
     # - https://github.com/MichaelGrupp/evo/blob/v1.22.0/evo/tools/file_interface.py#L279-L280
 
-    ${result} =  Perform trajectory analysis  bag2  ${BENCHMARK.OUTPUT.ROS.BAG}
-    ...                                       @{BENCHMARK.OUTPUT.SLAM.TRAJECTORIES}
-    ...                                       ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
-    ...                                       ref=${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
-    ...                                       ros_map_yaml=${BENCHMARK.OUTPUT.MAP.PATH}
-    ...                                       plot_mode=xy  save_plot=all.png
-    ...                                       no_warnings=yes  save_as_tum=yes
-    ...                                       &{BENCHMARK.OUTPUT.SLAM.CORRECTIONS}
-    ...                                       cwd=${BENCHMARK.CASE.ITERATION.PATH}
-    Should Be Equal  ${result.rc}  ${0}
-    Wait Until Created  ${BENCHMARK.CASE.ITERATION.PATH}/all_trajectories.png  timeout=10s
-    File Should Exist  ${BENCHMARK.CASE.ITERATION.PATH}/all_trajectories.png
+    ${result} =  Manipulate Trajectories  bag2  ${BENCHMARK.OUTPUT.ROS.BAG}
+    ...                                   @{BENCHMARK.OUTPUT.SLAM.TRAJECTORIES}
+    ...                                   no_warnings=yes  save_as_tum=yes
+    ...                                   cwd=${BENCHMARK.CASE.ITERATION.PATH}
+    Should Be Equal  ${result.rc}  ${0}  msg=${result.stderr}
 
+    @{trajectories} =  Create List
     FOR  ${trajectory}  IN  @{BENCHMARK.OUTPUT.SLAM.TRAJECTORIES}
-        ${stem} =  Convert To EVO Filestem  ${trajectory}  name_format=ros
-        ${result} =  Estimate APE  bag2  ${BENCHMARK.OUTPUT.ROS.BAG}
-        ...          ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}  ${trajectory}
-        ...          save_plot=${stem}.ape.png  save_results=${stem}.ape.zip
-        ...          plot_mode=xy  no_warnings=yes  &{BENCHMARK.OUTPUT.SLAM.CORRECTIONS}
-        ...          cwd=${BENCHMARK.CASE.ITERATION.PATH}
-        Should Be Equal  ${result.rc}  ${0}
-        Wait Until Created  ${BENCHMARK.CASE.ITERATION.PATH}/${stem}.ape.zip  timeout=10s
-        File Should Exist  ${BENCHMARK.CASE.ITERATION.PATH}/${stem}.ape.zip
-        ${result} =  Estimate RPE  bag2  ${BENCHMARK.OUTPUT.ROS.BAG}  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
-        ...          ${trajectory}  save_plot=${stem}.rpe.png  save_results=${stem}.rpe.zip
-        ...          plot_mode=xy  no_warnings=yes  &{BENCHMARK.OUTPUT.SLAM.CORRECTIONS}
-        ...          cwd=${BENCHMARK.CASE.ITERATION.PATH}
-        Should Be Equal  ${result.rc}  ${0}
-        Wait Until Created  ${BENCHMARK.CASE.ITERATION.PATH}/${stem}.rpe.zip  10s
-        File Should Exist  ${BENCHMARK.CASE.ITERATION.PATH}/${stem}.rpe.zip
+        ${filestem} =  Convert To EVO Filestem  ${trajectory}  name_format=ros
+        Append To List  ${trajectories}  ${filestem}.tum
     END
+
+    IF  ${BENCHMARK.OUTPUT.SLAM.USE_GROUNDTRUTH_FROM_FILE}
+        ${groundtruth_format} =  Infer Trajectory File Format  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
+        IF  "${groundtruth_format}" != "tum"
+            ${result} =  Manipulate Trajectories
+            ...    ${groundtruth_format}  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
+            ...    no_warnings=yes  save_as_tum=yes  cwd=${BENCHMARK.CASE.ITERATION.PATH}
+            Should Be Equal  ${result.rc}  ${0}  msg=${result.stderr}
+            ${filestem} =  Convert To EVO Filestem  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}  name_format=path
+            ${groundtruth} =  Set Variable  ${filestem}.tum
+        ELSE
+            ${groundtruth} =  Set Variable  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
+        END
+    ELSE
+        ${result} =  Manipulate Trajectories
+        ...    bag2  ${BENCHMARK.OUTPUT.ROS.BAG}  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
+        ...    no_warnings=yes  save_as_tum=yes  cwd=${BENCHMARK.CASE.ITERATION.PATH}
+        Should Be Equal  ${result.rc}  ${0}  msg=${result.stderr}
+        ${filestem} =  Convert To EVO Filestem  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}  name_format=ros
+        ${groundtruth} =  Set Variable  ${filestem}.tum
+    END
+
+    Perform TUM Trajectory Analysis
+    ...    @{trajectories}  ref=${groundtruth}  map=${BENCHMARK.OUTPUT.MAP.PATH}
+    ...    &{BENCHMARK.OUTPUT.SLAM.CORRECTIONS}  cwd=${BENCHMARK.CASE.ITERATION.PATH}

--- a/src/core/lambkin-shepherd/src/lambkin/shepherd/robot/resources/benchmarks/slam.resource
+++ b/src/core/lambkin-shepherd/src/lambkin/shepherd/robot/resources/benchmarks/slam.resource
@@ -25,6 +25,11 @@ Library   Collections
 Library   String
 
 
+*** Variables ***
+&{BENCHMARK.OUTPUT.SLAM.CORRECTIONS}  &{EMPTY}
+${BENCHMARK.OUTPUT.SLAM.USE_GROUNDTRUTH_FROM_FILE}  ${False}
+
+
 *** Keywords ***
 SLAM system benchmark suite
     [Documentation]  Generic SLAM system benchmark suite description.
@@ -76,4 +81,20 @@ Uses ${trajectory} as trajectory groundtruth
     [Tags]  declarative
     Variable Should Not Exist  $BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH
     ...  Ground truth trajectory is already set to ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}
-    Set Test Variable  $BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH  ${trajectory}
+    ${trajectory_path} =  Resolve File Path  ${trajectory}
+    IF  $trajectory_path != $null
+        Set Test Variable  $BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH  ${trajectory_path}
+        Set Test Variable  $BENCHMARK.OUTPUT.SLAM.USE_GROUNDTRUTH_FROM_FILE  ${True}
+    ELSE
+        Set Test Variable  $BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH  ${trajectory}
+    END
+
+### Hooks ###
+
+Before SLAM system benchmark case rig shutdown
+    [Documentation]
+    ...  See `Before ${some} benchmark case rig shutdown` documentation.
+    [Tags]  declarative  override
+    IF  ${BENCHMARK.OUTPUT.SLAM.USE_GROUNDTRUTH_FROM_FILE}
+        Copy File  ${BENCHMARK.OUTPUT.SLAM.GROUNDTRUTH}  ${BENCHMARK.CASE.ITERATION.PATH}/.
+    END

--- a/src/core/lambkin-shepherd/src/lambkin/shepherd/robot/resources/library/evo.resource
+++ b/src/core/lambkin-shepherd/src/lambkin/shepherd/robot/resources/library/evo.resource
@@ -23,7 +23,7 @@ Library   lambkin.shepherd.robot.api.evo
 
 
 *** Keywords ***
-Perform trajectory analysis
+Manipulate trajectories
     [Documentation]  Invokes evo_traj with arguments and options.
     [Arguments]  @{args}  ${cwd}=.  &{kwargs}
     [Tags]  imperative
@@ -46,3 +46,30 @@ Estimate RPE
     ${options} =  Convert To Command Line Options  &{kwargs}
     ${result} =  Run Managed Process  evo_rpe  @{args}  @{options}  cwd=${cwd}
     RETURN  ${result}
+
+Perform TUM Trajectory Analysis
+    [Documentation]  Performs basic trajectory analysis on a set of TUM formatted trajectories.
+    [Arguments]  @{trajectories}  ${ref}  ${map}  ${cwd}=.  &{kwargs}
+    [Tags]  imperative
+    ${result} =  Manipulate Trajectories  tum  @{trajectories}  ref=${ref}  ros_map_yaml=${map}
+    ...                                   plot_mode=xy  save_plot=all.png  no_warnings=yes
+    ...                                   cwd=${cwd}  &{kwargs}
+    Should Be Equal  ${result.rc}  ${0}  msg=${result.stderr}
+    Wait Until Created  ${cwd}/all_trajectories.png  timeout=10s
+    File Should Exist  ${cwd}/all_trajectories.png
+
+    FOR  ${trajectory}  IN  @{trajectories}
+        ${filestem} =  Convert To EVO Filestem  ${trajectory}  name_format=path
+        ${result} =  Estimate APE  tum  ${ref}  ${trajectory}  save_results=${filestem}.ape.zip
+        ...          save_plot=${filestem}.ape.png  plot_mode=xy  no_warnings=yes  cwd=${cwd}
+        ...          &{kwargs}
+        Should Be Equal  ${result.rc}  ${0}  msg=${result.stderr}
+        Wait Until Created  ${cwd}/${filestem}.ape.zip  timeout=10s
+        File Should Exist  ${cwd}/${filestem}.ape.zip
+        ${result} =  Estimate RPE  tum  ${ref}  ${trajectory}  save_results=${filestem}.rpe.zip
+        ...          save_plot=${filestem}.rpe.png  plot_mode=xy  no_warnings=yes  cwd=${cwd}
+        ...          &{kwargs}
+        Should Be Equal  ${result.rc}  ${0}  msg=${result.stderr}
+        Wait Until Created  ${cwd}/${filestem}.rpe.zip  10s
+        File Should Exist  ${cwd}/${filestem}.rpe.zip
+    END


### PR DESCRIPTION
### Proposed changes

As the title reads, this PR enables the use of trajectory groundtruth in TUM files as reference for accuracy analysis. `evo` isn't that powerful, so it normalizes everything to TUM files to get it to work. Builds on #72.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
  -  Relying on existing benchmark tests for regression.
- [x] I have added necessary documentation (if appropriate)
