### PR TITLE
Add ROS 2 data access APIs

### DIFF
--- a/src/core/lambkin-shepherd/.devcontainer/devcontainer.json
+++ b/src/core/lambkin-shepherd/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "ekumenlabs/lambkin:ubuntu-focal-dev",
+    "image": "ekumenlabs/lambkin:ubuntu-jammy-dev",
 
     "postCreateCommand": "sudo pip3 install -r requirements.txt",
 

--- a/src/core/lambkin-shepherd/src/lambkin/shepherd/data/__init__.py
+++ b/src/core/lambkin-shepherd/src/lambkin/shepherd/data/__init__.py
@@ -18,6 +18,7 @@ import lambkin.shepherd.data.access as access
 import lambkin.shepherd.data.evo as evo
 import lambkin.shepherd.data.pandas as pandas
 import lambkin.shepherd.data.ros as ros
+import lambkin.shepherd.data.ros2 as ros2
 import lambkin.shepherd.data.timem as timem
 
-__all__ = ['access', 'evo', 'pandas', 'ros', 'timem']
+__all__ = ['access', 'evo', 'pandas', 'ros', 'ros2', 'timem']

--- a/src/core/lambkin-shepherd/src/lambkin/shepherd/data/ros2.py
+++ b/src/core/lambkin-shepherd/src/lambkin/shepherd/data/ros2.py
@@ -1,0 +1,103 @@
+# Copyright 2023 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module provides APIs to access ROS 2 output in benchmarks."""
+
+import warnings
+
+from importlib import import_module
+from collections.abc import Mapping
+from typing import Any, Iterable, Optional, Tuple, Union
+
+from lambkin.shepherd.data import access
+from lambkin.shepherd.data.access import Location
+from lambkin.shepherd.utilities import enforce_nonempty
+
+from lambkin.shepherd.data.ros import OccupancyGridType
+from lambkin.shepherd.data.ros import occupancy_grids
+
+
+def messages(
+    topic_names: Optional[Union[Iterable[str], str]] = None,
+    target_iterations: Optional[Iterable[Location]] = None,
+    bag_name: str = 'output_bag'
+) -> Iterable[Tuple[Mapping, Tuple[str, Any, int]]]:
+    """
+    Yield ROS 2 messages for the given topics per benchmark iteration.
+
+    A ROS 2 bag must have been recorded during benchmarks. This will be the case whenever
+    working with ROS 2 based benchmarks.
+
+    :param topic_names: names of the recorded ROS 2 opics of interest. If none is specified,
+      messages for all topics in each ROS 2 bag are returned.
+    :param target_iterations: locations of benchmark case iterations to target. If not provided,
+      it defaults to all locations as returned by py:func:`lambkin.data.access.iterations()`.
+    :param bag_name: name of the ROS 2 bags in benchmarks' output. Matches the name used in
+      ROS 2 based benchmarks by default.
+    :returns: an iterable over tuples of benchmark iteration metadata, as a semi-structured
+      mapping, and triplets bearing topic name, message instance, and message timestamp.
+    """
+    if topic_names is not None:
+        if isinstance(topic_names, str):
+            topic_names = [topic_names]
+        else:
+            topic_names = list(topic_names)
+
+    if target_iterations is None:
+        target_iterations = access.iterations()
+    target_iterations = enforce_nonempty(
+        target_iterations, 'no target iterations')
+    assert target_iterations is not None
+
+    rosbag2 = import_module('rosbag2_py')
+    serialization = import_module('rclpy.serialization')
+    rosidl_runtime = import_module('rosidl_runtime_py.utilities')
+    for path, metadata in target_iterations:
+        bag_path = path / bag_name
+
+        if not bag_path.exists():
+            warnings.warn(f'{bag_path} is missing')
+            continue
+
+        reader = rosbag2.SequentialReader()
+        storage_options = rosbag2.StorageOptions(str(bag_path))
+        converter_options = rosbag2.ConverterOptions('', '')
+        reader.open(storage_options, converter_options)
+
+        message_types = {
+            entry.name: rosidl_runtime.get_message(entry.type)
+            for entry in reader.get_all_topics_and_types()
+        }
+
+        if topic_names is not None:
+            message_types = {
+                topic_name: message_type for topic_name, message_type
+                in message_types.items() if topic_name in topic_names}
+
+            if len(message_types) != len(topic_names):
+                missing_topic_names = set(topic_names) - set(message_types)
+                warnings.warn(f'{missing_topic_names} missing from {bag_path}')
+
+            storage_filter = rosbag2.StorageFilter(topics=topic_names)
+            reader.set_filter(storage_filter)
+
+        while reader.has_next():
+            topic_name, data, timestamp = reader.read_next()
+            msg = serialization.deserialize_message(
+                data, message_types[topic_name]
+            )
+            yield metadata, (topic_name, msg, timestamp)
+
+
+__all__ = ['OccupancyGridType', 'occupancy_grids', 'messages']

--- a/src/core/lambkin-shepherd/test/data/test_ros2.py
+++ b/src/core/lambkin-shepherd/test/data/test_ros2.py
@@ -1,0 +1,115 @@
+# Copyright 2023 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+import json
+import pytest
+import yaml
+
+import numpy as np
+
+from importlib import import_module
+
+from lambkin.shepherd.data import access
+from lambkin.shepherd.data.ros2 import messages
+from lambkin.shepherd.data.ros2 import occupancy_grids
+
+from utilities import make_directory_tree
+from utilities import module_missing
+
+
+@pytest.fixture
+def testing_data_path(tmp_path_factory):
+    path = tmp_path_factory.mktemp('data')
+
+    def make_ros_data(path, iteration):
+        path.mkdir()
+
+        rosbag2 = import_module('rosbag2_py')
+        writer = rosbag2.SequentialWriter()
+        storage_options = rosbag2.StorageOptions(str(path / 'output_bag'))
+        converter_options = rosbag2.ConverterOptions('', '')
+        writer.open(storage_options, converter_options)
+        writer.create_topic(rosbag2.TopicMetadata(
+            '/scale', 'std_msgs/msg/Int32', ''
+        ))
+        std_msgs = import_module('std_msgs.msg')
+        message = std_msgs.Int32(data=10**iteration)
+        serialization = import_module('rclpy.serialization')
+        data = serialization.serialize_message(message)
+        writer.write('/scale', data, 0)
+        del writer
+
+        Image = import_module('PIL.Image')
+        map_image = np.full((200, 200), 128, dtype=np.uint8)
+        with open(path / 'map.pgm', 'wb') as f:
+            Image.fromarray(map_image, mode='L').save(f)
+
+        map_metadata = {
+            'image': 'map.pgm',
+            'resolution': 0.1,
+            'origin': [0., 0., 0.],
+            'occupied_thresh': 0.7,
+            'free_thresh': 0.3,
+            'negate': 0
+        }
+        with open(path / 'map.yaml', 'w') as f:
+            f.write(yaml.safe_dump(map_metadata))
+
+    return make_directory_tree({
+        'cases': {
+            'foo': {
+                'metadata.json': json.dumps({'name': 'Foo'}),
+                'variations': [{
+                    'metadata.json': json.dumps({
+                        'parameters': {'scenario': 'nominal'}
+                    }),
+                    'iterations': [
+                        functools.partial(
+                            make_ros_data, iteration=i
+                        ) for i in range(3)
+                    ]
+                }]
+            }
+        }
+    }, path)
+
+
+@pytest.fixture(autouse=True)
+def testing_context(testing_data_path):
+    with access.benchmark(testing_data_path):
+        yield
+
+
+@pytest.mark.skipif(
+    module_missing('rosbag2_py'),
+    reason='some packages are not installed')
+def test_messages():
+    for metadata, (topic_name, message, timestamp) in messages('/scale'):
+        scale = 10**metadata['iteration']['index']
+        assert topic_name == '/scale'
+        assert message.data == scale
+        assert timestamp == 0
+
+
+@pytest.mark.skipif(
+    module_missing('rosbag2_py') or module_missing('PIL'),
+    reason='some package are not installed')
+def test_occupancy_grids():
+    for metadata, grid in occupancy_grids():
+        assert grid.info.resolution == 0.1
+        assert grid.info.height == 200
+        assert grid.info.width == 200
+        np.testing.assert_equal(np.array(grid.data), 50)


### PR DESCRIPTION
### Proposed changes

Precisely what the title says. We added support for ROS 2 benchmarks but we never replicated ROS data access APIs. This patch amends this.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [x] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
