### PR TITLE
Fix Earthile release target in Beluga vs Nav2 benchmark

### DIFF
--- a/src/benchmarks/beluga_vs_nav2/Earthfile
+++ b/src/benchmarks/beluga_vs_nav2/Earthfile
@@ -72,7 +72,7 @@ build:
 release:
     ARG distro=jammy
     ARG rosdistro  # forward
-    FROM lambkin+embed-ubuntu-release --distro=${distro} --rosdistro=${rosdistro} \
+    FROM lambkin+embed-ubuntu-release --distro=${distro} --rosdistro=${rosdistro}
     COPY (+build/application --distro=${distro} --rosdistro=${rosdistro}) /opt/ros/application
     RUN . /etc/profile && apt update && rosdep update && \
         rosdep install -i -y --from-path /opt/ros/application \


### PR DESCRIPTION
### Proposed changes

Running `./tools/earthly ./src/benchmarks/beluga_vs_nav2+release` doesn't work:

```
Error: src/benchmarks/beluga_vs_nav2/Earthfile:75:4 parse flag args: invalid argument COPY
in        github.com/Ekumen-OS/lambkin/src/benchmarks/beluga_vs_nav2:main+release --distro= --rosdistro=
```

This can be fixed by removing the backslash from the previous command, suggestion by @hidmic 

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 **Breaking change!** _Explain why a non-backwards compatible change is necessary or remove this line entirely if not applicable._

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Additional comments

_Anything worth mentioning to the reviewers._
