### PR TITLE
Fix rosdep install execution

### DIFF
--- a/src/benchmarks/beluga_vs_nav2/Earthfile
+++ b/src/benchmarks/beluga_vs_nav2/Earthfile
@@ -48,7 +48,7 @@ local-devel:
 build:
     ARG distro=jammy
     ARG rosdistro  # forward
-    FROM lambkin+ubuntu-devel --distro=${distro} --rosdistro=${rosdistro} --components="external/ros2"
+    lambkin+embed-ubuntu-devel --distro=${distro} --rosdistro=${rosdistro} --components="external/ros2"
     RUN mkdir -p /workspace/src
     WORKDIR /workspace
     RUN cd src && git clone https://github.com/Ekumen-OS/beluga

--- a/src/benchmarks/beluga_vs_nav2/Earthfile
+++ b/src/benchmarks/beluga_vs_nav2/Earthfile
@@ -34,7 +34,7 @@ devel:
         apt clean && rm -rf /var/lib/apt/lists/*
     RUN pip install linuxdoc sphinxcontrib.datatemplates sphinxcontrib-repl
     DO os+ADDUSER --user=${user} --uid=${uid} --gid=${gid} --workdir=/workspace
-    DO os+FIXUSER --user=${user} --workdir=/workspace/src
+    DO os+FIXUSER
     SAVE IMAGE ekumenlabs/beluga-vs-nav2:dev
 
 local-devel:

--- a/src/benchmarks/beluga_vs_nav2/Earthfile
+++ b/src/benchmarks/beluga_vs_nav2/Earthfile
@@ -34,6 +34,7 @@ devel:
         apt clean && rm -rf /var/lib/apt/lists/*
     RUN pip install linuxdoc sphinxcontrib.datatemplates sphinxcontrib-repl
     DO os+ADDUSER --user=${user} --uid=${uid} --gid=${gid} --workdir=/workspace
+    DO os+FIXUSER --user=${user} --workdir=/workspace/src
     SAVE IMAGE ekumenlabs/beluga-vs-nav2:dev
 
 local-devel:
@@ -48,14 +49,11 @@ local-devel:
 build:
     ARG distro=jammy
     ARG rosdistro  # forward
-    lambkin+embed-ubuntu-devel --distro=${distro} --rosdistro=${rosdistro} --components="external/ros2"
+    FROM lambkin+embed-ubuntu-devel --distro=${distro} --rosdistro=${rosdistro} --components="external/ros2"
     RUN mkdir -p /workspace/src
     WORKDIR /workspace
     RUN cd src && git clone https://github.com/Ekumen-OS/beluga
     COPY . src/beluga_vs_nav2
-    USER root
-    RUN rosdep fix-permissions
-    USER ${USER}
     RUN . /etc/profile && apt update && rosdep update && \
         rosdep install -y -i --from-paths src -t build -t buildtool -t test \
             --skip-keys 'lambkin-shepherd lambkin-clerk' && \

--- a/src/benchmarks/beluga_vs_nav2/Earthfile
+++ b/src/benchmarks/beluga_vs_nav2/Earthfile
@@ -16,6 +16,7 @@ VERSION 0.8
 
 IMPORT ../../external/os AS os
 IMPORT ../../.. AS lambkin
+IMPORT ../../external/rosdep AS rosdep
 
 devel:
     ARG distro=jammy
@@ -34,7 +35,7 @@ devel:
         apt clean && rm -rf /var/lib/apt/lists/*
     RUN pip install linuxdoc sphinxcontrib.datatemplates sphinxcontrib-repl
     DO os+ADDUSER --user=${user} --uid=${uid} --gid=${gid} --workdir=/workspace
-    DO os+FIXUSER
+    DO rosdep+FIXUSER
     SAVE IMAGE ekumenlabs/beluga-vs-nav2:dev
 
 local-devel:

--- a/src/benchmarks/beluga_vs_nav2/Earthfile
+++ b/src/benchmarks/beluga_vs_nav2/Earthfile
@@ -53,6 +53,9 @@ build:
     WORKDIR /workspace
     RUN cd src && git clone https://github.com/Ekumen-OS/beluga
     COPY . src/beluga_vs_nav2
+    USER root
+    RUN rosdep fix-permissions
+    USER ${USER}
     RUN . /etc/profile && apt update && rosdep update && \
         rosdep install -y -i --from-paths src -t build -t buildtool -t test \
             --skip-keys 'lambkin-shepherd lambkin-clerk' && \

--- a/src/external/os/Earthfile
+++ b/src/external/os/Earthfile
@@ -67,7 +67,4 @@ FIXUSER:
     FUNCTION
     ARG user
     ARG workdir=/home/${user}
-    IF [ -d "${workdir}" ]
-        RUN cd ${workdir}
-        RUN rosdep fix-permissions
-    END
+    RUN rosdep fix-permissions

--- a/src/external/os/Earthfile
+++ b/src/external/os/Earthfile
@@ -67,9 +67,7 @@ FIXUSER:
     FUNCTION
     ARG user
     ARG workdir=/home/${user}
-    USER root
     IF [ -d "${workdir}" ]
         RUN cd ${workdir}
         RUN rosdep fix-permissions
     END
-    USER ${user}

--- a/src/external/os/Earthfile
+++ b/src/external/os/Earthfile
@@ -65,6 +65,4 @@ ADDUSER:
 
 FIXUSER:
     FUNCTION
-    ARG user
-    ARG workdir=/home/${user}
     RUN rosdep fix-permissions

--- a/src/external/os/Earthfile
+++ b/src/external/os/Earthfile
@@ -62,3 +62,14 @@ ADDUSER:
     USER ${user}
     ENV HOME=/home/${user}
     WORKDIR ${workdir}
+
+FIXUSER:
+    FUNCTION
+    ARG user
+    ARG workdir=/home/${user}
+    USER root
+    IF [ -d "${workdir}" ]
+        RUN cd ${workdir}
+        RUN rosdep fix-permissions
+    END
+    USER ${user}

--- a/src/external/os/Earthfile
+++ b/src/external/os/Earthfile
@@ -62,7 +62,3 @@ ADDUSER:
     USER ${user}
     ENV HOME=/home/${user}
     WORKDIR ${workdir}
-
-FIXUSER:
-    FUNCTION
-    RUN rosdep fix-permissions

--- a/src/external/rosdep/Earthfile
+++ b/src/external/rosdep/Earthfile
@@ -1,0 +1,19 @@
+# Copyright 2024 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERSION 0.8
+
+FIXUSER:
+    FUNCTION
+    RUN rosdep fix-permissions


### PR DESCRIPTION


### Proposed changes

Running rosdep update and rosdep install returns a permission denied error as described in #114. This prevented the release target to be executed.

Adding a `rosdep fix-permissions` instruction to be run in sudo mode fixes the issue.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 **Breaking change!** _Explain why a non-backwards compatible change is necessary or remove this line entirely if not applicable._

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Additional comments

Fix #114
