### PR TITLE
Fix bad name for env var

### DIFF
--- a/src/benchmarks/beluga_vs_nav2_multi_dataset/Earthfile
+++ b/src/benchmarks/beluga_vs_nav2_multi_dataset/Earthfile
@@ -33,7 +33,7 @@ devel:
         apt clean && rm -rf /var/lib/apt/lists/*
     RUN pip install linuxdoc sphinxcontrib.datatemplates sphinxcontrib-repl
     COPY DEFAULT_FASTRTPS_PROFILES.xml /
-    ENV ROS2_DEFAULT_FASTRTPS_PROFILES_FILE=/DEFAULT_FASTRTPS_PROFILES.xml
+    ENV FASTRTPS_DEFAULT_PROFILES_FILE=/DEFAULT_FASTRTPS_PROFILES.xml
     DO os+ADDUSER --user=${user} --uid=${uid} --gid=${gid} --workdir=/workspace
     SAVE IMAGE ekumenlabs/beluga-vs-nav2:dev
 


### PR DESCRIPTION
### Proposed changes

Fixes the name of the FASTRTPS_DEFAULT_PROFILES_FILE name. Related to #94 

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

