### PR TITLE
Phase 3: core/decorators/option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.10"
 dependencies = [
     "evo>=1.34.3",
     "pydantic>=2.0",
-    "click>=8.0",
+    "click>=8.3.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ requires-python = ">=3.10"
 dependencies = [
     "evo>=1.34.3",
     "pydantic>=2.0",
+    "click>=8.0",
 ]
 
 [dependency-groups]

--- a/src/lambkin/core/decorators/__init__.py
+++ b/src/lambkin/core/decorators/__init__.py
@@ -16,7 +16,7 @@
 
 Provides the decorators used to define and configure benchmark functions:
 
-- @lambkin.option : registers CLI options so the benchmark decorator can inject
+- @lambkin.option : registers CLI options so the @benchmark decorator can inject
   them into "ctx.options".
 """
 

--- a/src/lambkin/core/decorators/__init__.py
+++ b/src/lambkin/core/decorators/__init__.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Benchmark decorators for lambkin.
+"""Decorators for lambkin.
 
 Provides the decorators used to define and configure benchmark functions:
 
-- @lambkin.option : registers CLI options and injects them into "ctx.options".
+- @lambkin.option : registers CLI options so the benchmark decorator can inject
+  them into "ctx.options".
 """
 
 from .option import option

--- a/src/lambkin/core/decorators/__init__.py
+++ b/src/lambkin/core/decorators/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark decorators for lambkin.
+
+Provides the decorators used to define and configure benchmark functions:
+
+- @lambkin.option : registers CLI options and injects them into "ctx.options".
+"""
+
+from .option import option
+
+__all__ = [
+    "option",
+]

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark loop decorator for lambkin."""

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -12,7 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Decorators for the lambkin benchmark API.
-
-Provides @lambkin.benchmark, @lambkin.option decorators.
-"""
+"""Input decorator for lambkin."""

--- a/src/lambkin/core/decorators/option.py
+++ b/src/lambkin/core/decorators/option.py
@@ -32,13 +32,13 @@ def option(*param_decls, **attrs):
         @lambkin.option("--clock-rate", default=100.0)
         @lambkin.option("--sensor-topic", default="/scan")
     """
+    for decl in param_decls:
+        if not decl.startswith("-"):
+            raise ValueError(
+                f"Invalid flag name: {decl!r}. Must start with '-' or '--'."
+            )
 
     def decorator(fn):
-        for decl in param_decls:
-            if not decl.startswith("-"):
-                raise ValueError(
-                    f"Invalid flag name: {decl!r}. Must start with '-' or '--'."
-                )
         if not hasattr(fn, "__lambkin_options__"):
             fn.__lambkin_options__ = []
         fn.__lambkin_options__.append(Option(param_decls, **attrs))

--- a/src/lambkin/core/decorators/option.py
+++ b/src/lambkin/core/decorators/option.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI option registration for benchmark.
+
+Provides the option decorator.. Instead of parsing arguments immediately, it
+stores option definitions on the function so that later can parse and inject
+them into "ctx.options" later.
+
+Flag names are normalized to Python attributes:
+"--clock-rate"->"ctx.options.clock_rate".
+"""
+
+
+def option(*param_decls, **attrs):
+    """Registers a CLI option on the benchmark function.
+
+    Example:
+        @l.option("--clock-rate", default=100.0)
+        @l.option("--sensor-topic", default="/scan")
+    """
+
+    def decorator(fn):
+        if not hasattr(fn, "_options"):
+            fn._options = []
+        fn._options.append((param_decls, attrs))
+        return fn
+
+    return decorator

--- a/src/lambkin/core/decorators/option.py
+++ b/src/lambkin/core/decorators/option.py
@@ -16,8 +16,8 @@
 
 Provides the @option decorator, modeled directly after click.option. Instead of
 parsing arguments immediately, it creates a class click.Option object and stores
-it on "fn._options" so that @benchmark can collect and parse them
-later and inject the resulting values into "ctx.options".
+it on "fn._options" so that @benchmark can collect and parse them later and
+inject the resulting values into "ctx.options".
 
 Flag names are normalized by click: "--clock-rate" becomes "clock_rate".
 """

--- a/src/lambkin/core/decorators/option.py
+++ b/src/lambkin/core/decorators/option.py
@@ -16,7 +16,7 @@
 
 Provides the @option decorator, modeled directly after click.option. Instead of
 parsing arguments immediately, it creates a class click.Option object and stores
-it on "fn._options" so that @benchmark can collect and parse them later and
+it on "fn.__lambkin_options__" so that @benchmark can collect and parse them later and
 inject the resulting values into "ctx.options".
 
 Flag names are normalized by click: "--clock-rate" becomes "clock_rate".
@@ -34,9 +34,14 @@ def option(*param_decls, **attrs):
     """
 
     def decorator(fn):
-        if not hasattr(fn, "_options"):
-            fn._options = []
-        fn._options.append(Option(param_decls, **attrs))
+        for decl in param_decls:
+            if not decl.startswith("-"):
+                raise ValueError(
+                    f"Invalid flag name: {decl!r}. Must start with '-' or '--'."
+                )
+        if not hasattr(fn, "__lambkin_options__"):
+            fn.__lambkin_options__ = []
+        fn.__lambkin_options__.append(Option(param_decls, **attrs))
         return fn
 
     return decorator

--- a/src/lambkin/core/decorators/option.py
+++ b/src/lambkin/core/decorators/option.py
@@ -22,7 +22,7 @@ later and inject the resulting values into "ctx.options".
 Flag names are normalized by click: "--clock-rate" becomes "clock_rate".
 """
 
-import click
+from click import Option
 
 
 def option(*param_decls, **attrs):
@@ -36,7 +36,7 @@ def option(*param_decls, **attrs):
     def decorator(fn):
         if not hasattr(fn, "_options"):
             fn._options = []
-        fn._options.append(click.Option(param_decls, **attrs))
+        fn._options.append(Option(param_decls, **attrs))
         return fn
 
     return decorator

--- a/src/lambkin/core/decorators/option.py
+++ b/src/lambkin/core/decorators/option.py
@@ -14,12 +14,15 @@
 
 """CLI option registration for benchmark.
 
-Provides the @option decorator. Instead of parsing arguments immediately, it
-stores option definitions on the function.
+Provides the @option decorator, modeled directly after click.option. Instead of
+parsing arguments immediately, it creates a class click.Option object and stores
+it on "fn._options" so that @benchmark can collect and parse them
+later and inject the resulting values into "ctx.options".
 
-The @benchmark orchestrator later collects these definitions to construct a
-unified CLI parser and inject the resulting values into "ctx.options".
+Flag names are normalized by click: "--clock-rate" becomes "clock_rate".
 """
+
+import click
 
 
 def option(*param_decls, **attrs):
@@ -33,7 +36,7 @@ def option(*param_decls, **attrs):
     def decorator(fn):
         if not hasattr(fn, "_options"):
             fn._options = []
-        fn._options.append((param_decls, attrs))
+        fn._options.append(click.Option(param_decls, **attrs))
         return fn
 
     return decorator

--- a/src/lambkin/core/decorators/option.py
+++ b/src/lambkin/core/decorators/option.py
@@ -14,12 +14,12 @@
 
 """CLI option registration for benchmark.
 
-Provides the option decorator.. Instead of parsing arguments immediately, it
+Provides the option decorator. Instead of parsing arguments immediately, it
 stores option definitions on the function so that later can parse and inject
-them into "ctx.options" later.
+them into "ctx.options".
 
-Flag names are normalized to Python attributes:
-"--clock-rate"->"ctx.options.clock_rate".
+The @benchmark orchestrator later collects these definitions to construct a
+unified CLI parser and inject the resulting values into ctx.options.
 """
 
 
@@ -27,8 +27,8 @@ def option(*param_decls, **attrs):
     """Registers a CLI option on the benchmark function.
 
     Example:
-        @l.option("--clock-rate", default=100.0)
-        @l.option("--sensor-topic", default="/scan")
+        @lambkin.option("--clock-rate", default=100.0)
+        @lambkin.option("--sensor-topic", default="/scan")
     """
 
     def decorator(fn):

--- a/src/lambkin/core/decorators/option.py
+++ b/src/lambkin/core/decorators/option.py
@@ -14,12 +14,11 @@
 
 """CLI option registration for benchmark.
 
-Provides the option decorator. Instead of parsing arguments immediately, it
-stores option definitions on the function so that later can parse and inject
-them into "ctx.options".
+Provides the @option decorator. Instead of parsing arguments immediately, it
+stores option definitions on the function.
 
 The @benchmark orchestrator later collects these definitions to construct a
-unified CLI parser and inject the resulting values into ctx.options.
+unified CLI parser and inject the resulting values into "ctx.options".
 """
 
 

--- a/test/core/test_option.py
+++ b/test/core/test_option.py
@@ -30,21 +30,21 @@ def simple_fn():
 
 
 def test_option_stores_single_option(simple_fn):
-    """@l.option stores one option definition on the function."""
+    """@lambkin.option stores one option definition on the function."""
     decorated = option("--clock-rate", default=100.0)(simple_fn)
     assert len(decorated._options) == 1
     assert decorated._options[0] == (("--clock-rate",), {"default": 100.0})
 
 
 def test_option_stacks_multiple_decorators(simple_fn):
-    """Multiple @l.option decorators each add one entry to fn._options."""
+    """Multiple @lambkin.option decorators each add one entry to fn._options."""
     decorated = option("--clock-rate", default=100.0)(simple_fn)
     decorated = option("--sensor-topic", default="/scan")(decorated)
     assert len(decorated._options) == 2
 
 
 def test_option_stores_attrs_correctly(simple_fn):
-    """@l.option stores all kwargs correctly."""
+    """@lambkin.option stores all kwargs correctly."""
     decorated = option("--clock-rate", default=100.0)(simple_fn)
     _, attrs = decorated._options[0]
     assert attrs["default"] == 100.0

--- a/test/core/test_option.py
+++ b/test/core/test_option.py
@@ -14,6 +14,7 @@
 
 """Unit tests for the option decorator in lambkin.core.decorators."""
 
+import click
 import pytest
 
 from lambkin.core.decorators.option import option
@@ -30,10 +31,10 @@ def simple_fn():
 
 
 def test_option_stores_single_option(simple_fn):
-    """@lambkin.option stores one option definition on the function."""
+    """@lambkin.option stores one click.Option on the function."""
     decorated = option("--clock-rate", default=100.0)(simple_fn)
     assert len(decorated._options) == 1
-    assert decorated._options[0] == (("--clock-rate",), {"default": 100.0})
+    assert isinstance(decorated._options[0], click.Option)
 
 
 def test_option_stacks_multiple_decorators(simple_fn):
@@ -43,27 +44,22 @@ def test_option_stacks_multiple_decorators(simple_fn):
     assert len(decorated._options) == 2
 
 
-def test_option_stores_attrs_correctly(simple_fn):
-    """@lambkin.option stores all kwargs correctly."""
+def test_option_default_is_stored(simple_fn):
+    """@lambkin.option stores the default value correctly."""
     decorated = option("--clock-rate", default=100.0)(simple_fn)
-    _, attrs = decorated._options[0]
-    assert attrs["default"] == 100.0
+    assert decorated._options[0].default == 100.0
 
 
-def test_option_normalization_single_flag(simple_fn):
-    """--clock-rate normalizes to clock_rate."""
+def test_option_normalizes_flag_name(simple_fn):
+    """--clock-rate is normalized to clock_rate by click."""
     decorated = option("--clock-rate", default=100.0)(simple_fn)
-    param_decls, _ = decorated._options[0]
-    key = max(param_decls, key=len).lstrip("-").replace("-", "_")
-    assert key == "clock_rate"
+    assert decorated._options[0].name == "clock_rate"
 
 
-def test_option_normalization_picks_longest_flag(simple_fn):
+def test_option_picks_longest_flag(simple_fn):
     """--clock-rate is picked over -c when normalizing."""
     decorated = option("--clock-rate", "-c", default=100.0)(simple_fn)
-    param_decls, _ = decorated._options[0]
-    key = max(param_decls, key=len).lstrip("-").replace("-", "_")
-    assert key == "clock_rate"
+    assert decorated._options[0].name == "clock_rate"
 
 
 def test_option_no_options_by_default(simple_fn):

--- a/test/core/test_option.py
+++ b/test/core/test_option.py
@@ -44,24 +44,6 @@ def test_option_stacks_multiple_decorators(simple_fn):
     assert len(decorated._options) == 2
 
 
-def test_option_default_is_stored(simple_fn):
-    """@lambkin.option stores the default value correctly."""
-    decorated = option("--clock-rate", default=100.0)(simple_fn)
-    assert decorated._options[0].default == 100.0
-
-
-def test_option_normalizes_flag_name(simple_fn):
-    """--clock-rate is normalized to clock_rate by click."""
-    decorated = option("--clock-rate", default=100.0)(simple_fn)
-    assert decorated._options[0].name == "clock_rate"
-
-
-def test_option_picks_longest_flag(simple_fn):
-    """--clock-rate is picked over -c when normalizing."""
-    decorated = option("--clock-rate", "-c", default=100.0)(simple_fn)
-    assert decorated._options[0].name == "clock_rate"
-
-
 def test_option_no_options_by_default(simple_fn):
     """A plain function has no _options attribute."""
     assert not hasattr(simple_fn, "_options")

--- a/test/core/test_option.py
+++ b/test/core/test_option.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the option decorator in lambkin.core.decorators."""
+
+import pytest
+
+from lambkin.core.decorators.option import option
+
+
+@pytest.fixture
+def simple_fn():
+    """A plain function to decorate."""
+
+    def fn():
+        pass
+
+    return fn
+
+
+def test_option_stores_single_option(simple_fn):
+    """@l.option stores one option definition on the function."""
+    decorated = option("--clock-rate", default=100.0)(simple_fn)
+    assert len(decorated._options) == 1
+    assert decorated._options[0] == (("--clock-rate",), {"default": 100.0})
+
+
+def test_option_stacks_multiple_decorators(simple_fn):
+    """Multiple @l.option decorators each add one entry to fn._options."""
+    decorated = option("--clock-rate", default=100.0)(simple_fn)
+    decorated = option("--sensor-topic", default="/scan")(decorated)
+    assert len(decorated._options) == 2
+
+
+def test_option_stores_attrs_correctly(simple_fn):
+    """@l.option stores all kwargs correctly."""
+    decorated = option("--clock-rate", default=100.0)(simple_fn)
+    _, attrs = decorated._options[0]
+    assert attrs["default"] == 100.0
+
+
+def test_option_normalization_single_flag(simple_fn):
+    """--clock-rate normalizes to clock_rate."""
+    decorated = option("--clock-rate", default=100.0)(simple_fn)
+    param_decls, _ = decorated._options[0]
+    key = max(param_decls, key=len).lstrip("-").replace("-", "_")
+    assert key == "clock_rate"
+
+
+def test_option_normalization_picks_longest_flag(simple_fn):
+    """--clock-rate is picked over -c when normalizing."""
+    decorated = option("--clock-rate", "-c", default=100.0)(simple_fn)
+    param_decls, _ = decorated._options[0]
+    key = max(param_decls, key=len).lstrip("-").replace("-", "_")
+    assert key == "clock_rate"
+
+
+def test_option_no_options_by_default(simple_fn):
+    """A plain function has no _options attribute."""
+    assert not hasattr(simple_fn, "_options")

--- a/test/core/test_option.py
+++ b/test/core/test_option.py
@@ -14,8 +14,8 @@
 
 """Unit tests for the option decorator in lambkin.core.decorators."""
 
-import click
 import pytest
+from click import Option
 
 from lambkin.core.decorators.option import option
 
@@ -30,20 +30,56 @@ def simple_fn():
     return fn
 
 
+def test_option_uses_namespaced_dunder(simple_fn):
+    """Verify we use the protected __lambkin_options__ attribute for safety."""
+    decorated = option("--clock-rate")(simple_fn)
+    assert hasattr(decorated, "__lambkin_options__")
+
+
 def test_option_stores_single_option(simple_fn):
     """@lambkin.option stores one click.Option on the function."""
     decorated = option("--clock-rate", default=100.0)(simple_fn)
-    assert len(decorated._options) == 1
-    assert isinstance(decorated._options[0], click.Option)
+    assert len(decorated.__lambkin_options__) == 1
+    assert isinstance(decorated.__lambkin_options__[0], Option)
 
 
-def test_option_stacks_multiple_decorators(simple_fn):
-    """Multiple @lambkin.option decorators each add one entry to fn._options."""
+def test_option_is_real_click_object(simple_fn):
+    """Verify we are actually storing click.Option objects, not tuples."""
     decorated = option("--clock-rate", default=100.0)(simple_fn)
-    decorated = option("--sensor-topic", default="/scan")(decorated)
-    assert len(decorated._options) == 2
+    opt = decorated.__lambkin_options__[0]
+    assert isinstance(opt, Option)
+    assert opt.name == "clock_rate"
+
+
+def test_option_stacks_multiple_decorators():
+    """Multiple @option decorators append to __lambkin_options__, not overwrite."""
+
+    @option("--clock-rate", default=100.0)
+    @option("--sensor-topic", default="/scan")
+    def fn():
+        pass
+
+    assert len(fn.__lambkin_options__) == 2
+
+
+def test_option_stacks_bottom_up():
+    """Decorators are applied bottom-up, so --sensor-topic is first."""
+
+    @option("--clock-rate", default=100.0)
+    @option("--sensor-topic", default="/scan")
+    def fn():
+        pass
+
+    assert fn.__lambkin_options__[0].name == "sensor_topic"
+    assert fn.__lambkin_options__[1].name == "clock_rate"
+
+
+def test_option_fails_on_invalid_declaration(simple_fn):
+    """option() raises an error if the flag name is invalid."""
+    with pytest.raises(ValueError):
+        option("clock-rate")(simple_fn)
 
 
 def test_option_no_options_by_default(simple_fn):
     """A plain function has no _options attribute."""
-    assert not hasattr(simple_fn, "_options")
+    assert not hasattr(simple_fn, "__lambkin_options__")

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -426,6 +438,7 @@ name = "lambkin"
 version = "0.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "evo" },
     { name = "pydantic" },
 ]
@@ -439,6 +452,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0" },
     { name = "evo", specifier = ">=1.34.3" },
     { name = "pydantic", specifier = ">=2.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -452,7 +452,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.0" },
+    { name = "click", specifier = ">=8.3.0" },
     { name = "evo", specifier = ">=1.34.3" },
     { name = "pydantic", specifier = ">=2.0" },
 ]


### PR DESCRIPTION
### Proposed changes

This PR adds the option decorator to lambkin/core/decorators/option.py.

This decorator registers CLI option definitions directly onto the benchmark function. Rather than parsing the arguments itself, it simply stores the definitions in fn._options to be injected into ctx.options later.


#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Additional comments

_Anything worth mentioning to the reviewers._
