### PR TITLE
Phase 3: make output_dir optional in Context class

### DIFF
--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -94,10 +94,10 @@ class Context:
         self,
         variant: dict[str, Any],
         iteration: int,
-        output_dir: Path | str,
         options: dict[str, Any],
         source: Source,
         variant_index: int = 0,
+        output_dir: Path | str | None = None,
     ) -> None:
         """Initialize a Context for one (variant, iteration) benchmark run.
 

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -33,27 +33,31 @@ class OutputInfo:
 
     Attributes:
     ----------
+    base_dir :
+        Base output folder for benchmark.(e.g. results/).
     variant_dir:
         Root folder for this variant (e.g.
         results/var_1/).
     iteration_dir:
-        Folder for the current iteration (e.g.
-        results/var_1/iter_1/).
+        Folder for the current iteration (e.g. results/var_1/iter_1/).
     """
 
-    def __init__(self, variant_dir: Path, iteration_dir: Path) -> None:
+    def __init__(self, base_dir: Path, variant_dir: Path, iteration_dir: Path) -> None:
         """Initialize the output paths for one (variant, iteration) pair.
 
         Parameters
         ----------
+        base_dir : Path
+            Base output folder for benchmark.(e.g. results/).
         variant_dir : Path
             Root output folder for this variant
             (e.g. results/var_1/).
         iteration_dir : Path
-            Output folder for the current iteration
-            (e.g. results/var_1/iter_1/).
+            Output folder for the current iteration (e.g.
+            results/var_1/iter_1/).
         """
         self.variant_dir = Path(variant_dir)
+        self.base_dir = Path(base_dir)
         self.iteration_dir = Path(iteration_dir)
 
 
@@ -144,10 +148,15 @@ class Context:
         self.iteration = iteration
 
         # ctx.output
-        base = Path(output_dir) if output_dir else source.path.parent / "results"
+        base = (
+            Path(output_dir)
+            if output_dir
+            else source.path.parent / Context.BENCHMARKS_DIRNAME
+        )
         variant_dir = base / _variant_folder_name(variant_index)
         iteration_dir = variant_dir / _iteration_folder_name(iteration)
         self.output = OutputInfo(
+            base_dir=base,
             variant_dir=variant_dir,
             iteration_dir=iteration_dir,
         )

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -80,7 +80,9 @@ class Context:
 
     Attributes:
     ----------
-    variant:
+    BENCHMARKS_DIRNAME : str
+        Name for the benchmarks directory.
+    variation:
         Namespaced algorithm parameters for this run.
         All key-value pairs from the variant dict are exposed as attributes.
     source:
@@ -93,6 +95,8 @@ class Context:
     output:
         Namespaced output paths.
     """
+
+    BENCHMARKS_DIRNAME = "results"
 
     def __init__(
         self,

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -151,6 +151,12 @@ class Context:
         # ctx.iteration
         self.iteration = iteration
 
+        # TODO: Consider moving path construction logic into OutputInfo itself,
+        # giving it a constructor that takes base_dir, variation_index, and
+        # iteration and derives variation_dir and iteration_dir internally. This
+        # would make OutputInfo a cohesive object that owns everything
+        # path-related.
+
         # ctx.output
         base = (
             Path(output_dir)

--- a/test/core/test_context.py
+++ b/test/core/test_context.py
@@ -215,14 +215,14 @@ def test_context_default_output_dir(tmp_path):
     """Default output_dir resolves relative to the benchmark script.
 
     When output_dir is not provided, it defaults to source.path.parent /
-    OutputInfo.BENCHMARKS_DIRNAME.
+    Context.BENCHMARKS_DIRNAME.
     """
     script = tmp_path / "my_benchmark.py"
     script.touch()
 
     source = Source(path=script)
     ctx = Context(
-        variation={"sensor_model": "beam", "num_particles": 10},
+        variant={"sensor_model": "beam", "num_particles": 10},
         iteration=0,
         options={},
         source=source,

--- a/test/core/test_context.py
+++ b/test/core/test_context.py
@@ -212,9 +212,10 @@ def test_iteration_stored(tmp_path, base_variant, base_options, base_source, ite
 
 
 def test_context_default_output_dir(tmp_path):
-    """When output_dir is not provided.
+    """Default output_dir resolves relative to the benchmark script.
 
-    It defaults to source.path.parent / OutputInfo.BENCHMARKS_DIRNAME.
+    When output_dir is not provided, it defaults to source.path.parent /
+    OutputInfo.BENCHMARKS_DIRNAME.
     """
     script = tmp_path / "my_benchmark.py"
     script.touch()

--- a/test/core/test_context.py
+++ b/test/core/test_context.py
@@ -19,7 +19,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from lambkin.core.ctx.context import Context, OutputInfo
+from lambkin.core.ctx.context import Context
 from lambkin.core.ctx.source import Source
 
 
@@ -226,4 +226,4 @@ def test_context_default_output_dir(tmp_path):
         options={},
         source=source,
     )
-    assert ctx.output.base_dir == tmp_path / OutputInfo.BENCHMARKS_DIRNAME
+    assert ctx.output.base_dir == tmp_path / Context.BENCHMARKS_DIRNAME

--- a/test/core/test_context.py
+++ b/test/core/test_context.py
@@ -209,3 +209,21 @@ def test_iteration_stored(tmp_path, base_variant, base_options, base_source, ite
         source=base_source,
     )
     assert ctx.iteration == iteration
+
+
+def test_context_default_output_dir(tmp_path):
+    """When output_dir is not provided.
+
+    It defaults to source.path.parent /"results".
+    """
+    script = tmp_path / "my_benchmark.py"
+    script.touch()
+
+    source = Source(path=script)
+    ctx = Context(
+        variation={"sensor_model": "beam", "num_particles": 10},
+        iteration=0,
+        options={},
+        source=source,
+    )
+    assert ctx.output.variation_dir.parent == tmp_path / "results"

--- a/test/core/test_context.py
+++ b/test/core/test_context.py
@@ -19,7 +19,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from lambkin.core.ctx.context import Context
+from lambkin.core.ctx.context import Context, OutputInfo
 from lambkin.core.ctx.source import Source
 
 
@@ -214,7 +214,7 @@ def test_iteration_stored(tmp_path, base_variant, base_options, base_source, ite
 def test_context_default_output_dir(tmp_path):
     """When output_dir is not provided.
 
-    It defaults to source.path.parent /"results".
+    It defaults to source.path.parent / OutputInfo.BENCHMARKS_DIRNAME.
     """
     script = tmp_path / "my_benchmark.py"
     script.touch()
@@ -226,4 +226,4 @@ def test_context_default_output_dir(tmp_path):
         options={},
         source=source,
     )
-    assert ctx.output.variation_dir.parent == tmp_path / "results"
+    assert ctx.output.base_dir == tmp_path / OutputInfo.BENCHMARKS_DIRNAME


### PR DESCRIPTION
### Proposed changes

This PR makes output_dir an optional parameter in Context class.

When not provided, output_dir defaults to source.path.parent / "results",so the benchmark results are written next to the benchmark script without requiring the user to specify a path explicitly.

A test is added to verify this default behaviour — it constructs a Context without passing output_dir and asserts that the output directory is resolved relative to the benchmark script location.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 **Breaking change!** _Explain why a non-backwards compatible change is necessary or remove this line entirely if not applicable._

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Additional comments

_Anything worth mentioning to the reviewers._
