### PR TITLE
Phase 3: core/decorators/benchmark

### DIFF
--- a/src/lambkin/__init__.py
+++ b/src/lambkin/__init__.py
@@ -13,3 +13,11 @@
 # limitations under the License.
 
 """LAMBKIN: Localization And Mapping BenchmarKINg SDK."""
+
+from lambkin.core.decorators.benchmark import benchmark
+from lambkin.core.decorators.option import option
+
+__all__ = [
+    "option",
+    "benchmark",
+]

--- a/src/lambkin/__init__.py
+++ b/src/lambkin/__init__.py
@@ -14,10 +14,12 @@
 
 """LAMBKIN: Localization And Mapping BenchmarKINg SDK."""
 
+from lambkin.common.named_product import named_product
 from lambkin.core.decorators.benchmark import benchmark
 from lambkin.core.decorators.option import option
 
 __all__ = [
     "option",
     "benchmark",
+    "named_product",
 ]

--- a/src/lambkin/__init__.py
+++ b/src/lambkin/__init__.py
@@ -14,12 +14,11 @@
 
 """LAMBKIN: Localization And Mapping BenchmarKINg SDK."""
 
-from lambkin.common.named_product import named_product
-from lambkin.core.decorators.benchmark import benchmark
-from lambkin.core.decorators.option import option
+from lambkin.common import named_product
+from lambkin.core.decorators import benchmark, option
 
 __all__ = [
-    "option",
     "benchmark",
     "named_product",
+    "option",
 ]

--- a/src/lambkin/core/decorators/__init__.py
+++ b/src/lambkin/core/decorators/__init__.py
@@ -21,5 +21,5 @@ Provides the decorators used to define and configure benchmark functions:
 
 - @lambkin.benchmark : It collects CLI option definitions registered by @option,
   parses them once before the loop using an internal click parser, and injects
-  the resulting values into a Context class on each (variation, iteration)
+  the resulting values into a Context class on each (variant, iteration)
 """

--- a/src/lambkin/core/decorators/__init__.py
+++ b/src/lambkin/core/decorators/__init__.py
@@ -18,12 +18,8 @@ Provides the decorators used to define and configure benchmark functions:
 
 - @lambkin.option : registers CLI options so the @benchmark decorator can inject
   them into "ctx.options".
+
+- @lambkin.benchmark : It collects CLI option definitions registered by @option,
+  parses them once before the loop using an internal click parser, and injects
+  the resulting values into a Context class on each (variation, iteration)
 """
-
-# from .option import option
-# from .benchmark import benchmark
-
-# __all__ = [
-#     "option",
-#     "benchmark",
-# ]

--- a/src/lambkin/core/decorators/__init__.py
+++ b/src/lambkin/core/decorators/__init__.py
@@ -25,9 +25,9 @@ Provides the decorators used to define and configure benchmark functions:
 """
 
 from .benchmark import benchmark
-from .option import Option
+from .option import option
 
 __all__ = [
-    "Option",
+    "option",
     "benchmark",
 ]

--- a/src/lambkin/core/decorators/__init__.py
+++ b/src/lambkin/core/decorators/__init__.py
@@ -23,3 +23,11 @@ Provides the decorators used to define and configure benchmark functions:
   parses them once before the loop using an internal click parser, and injects
   the resulting values into a Context class on each (variant, iteration)
 """
+
+from .benchmark import benchmark
+from .option import Option
+
+__all__ = [
+    "Option",
+    "benchmark",
+]

--- a/src/lambkin/core/decorators/__init__.py
+++ b/src/lambkin/core/decorators/__init__.py
@@ -20,8 +20,10 @@ Provides the decorators used to define and configure benchmark functions:
   them into "ctx.options".
 """
 
-from .option import option
+# from .option import option
+# from .benchmark import benchmark
 
-__all__ = [
-    "option",
-]
+# __all__ = [
+#     "option",
+#     "benchmark",
+# ]

--- a/src/lambkin/core/decorators/__init__.py
+++ b/src/lambkin/core/decorators/__init__.py
@@ -16,18 +16,18 @@
 
 Provides the decorators used to define and configure benchmark functions:
 
-- @lambkin.option : registers CLI options so the @benchmark decorator can inject
-  them into "ctx.options".
-
 - @lambkin.benchmark : It collects CLI option definitions registered by @option,
   parses them once before the loop using an internal click parser, and injects
   the resulting values into a Context class on each (variant, iteration)
+
+- @lambkin.option : registers CLI options so the @benchmark decorator can inject
+  them into "ctx.options".
 """
 
 from .benchmark import benchmark
 from .option import option
 
 __all__ = [
-    "option",
     "benchmark",
+    "option",
 ]

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -14,6 +14,7 @@
 
 """Benchmark loop decorator for lambkin."""
 
+import inspect
 import sys
 
 import click
@@ -22,13 +23,13 @@ from lambkin.core.ctx.context import Context
 from lambkin.core.ctx.source import Source
 
 
-def _parse_options(fn):
+def _parse_options(fn, cli_args):
     """Parse CLI options from fn.__lambkin_options__ and return a dict."""
     registered = getattr(fn, "__lambkin_options__", [])
     if not registered:
         return {}
     cmd = click.Command(name="benchmark", params=registered)
-    click_ctx = cmd.make_context("benchmark", sys.argv[1:], allow_extra_args=True)
+    click_ctx = cmd.make_context("benchmark", list(cli_args))
     return click_ctx.params
 
 
@@ -50,9 +51,10 @@ def benchmark(variants, num_iterations):
     """
 
     def decorator(fn):
-        def wrapper():
-            options = _parse_options(fn)
-            source = Source(path=fn.__code__.co_filename)
+        def wrapper(args=None):
+            cli_args = sys.argv[1:] if args is None else args
+            options = _parse_options(fn, cli_args)
+            source = Source(path=inspect.getfile(fn))
             for variation_index, variation in enumerate(variants):
                 for iteration in range(num_iterations):
                     ctx = Context(

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Benchmark loop decorator for lambkin."""
+"""Benchmark loop decorator for lambkin.
+
+Provides the @benchmark decorator, which drives the execution loopover all
+variants and iterations. It collects CLI option definitions registered by
+@option, parses them once before the loop using an internal click parser, and
+injects the resulting values into a Context class on each (variation, iteration)
+pair.
+
+"""
 
 import inspect
 import sys

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -66,9 +66,13 @@ def benchmark(variants, num_iterations):
             for variation_index, variation in enumerate(variants):
                 for iteration in range(num_iterations):
                     ctx = Context(
+                        # TODO(teresa-ortega): change the name variation.
+                        # variation-> variant.
                         variation=variation,
                         iteration=iteration,
                         output_dir=".",
+                        # TODO(teresa-ortega): change the output_dir
+                        # implementation.
                         options=options,
                         source=source,
                         variation_index=variation_index,

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -17,7 +17,7 @@
 Provides the @benchmark decorator, which drives the execution loopover all
 variants and iterations. It collects CLI option definitions registered by
 @option, parses them once before the loop using an internal click parser, and
-injects the resulting values into a Context class on each (variation, iteration)
+injects the resulting values into a Context class on each (variant, iteration)
 pair.
 
 """
@@ -46,17 +46,17 @@ def benchmark(variants, num_iterations):
     """Drive the benchmark execution loop over all variants and iterations.
 
     Parses CLI options registered by @lambkin.option once before the loop,
-    then creates a Context for each (variants, iteration) pair and calls
+    then creates a Context for each (variant, iteration) pair and calls
     the decorated function with it.
 
     Parameters
     ----------
     variants : iterable of dict
-        Sequence of variation dicts to sweep over. Each dict is exposed
-        as attributes on ctx.variation.
+        Sequence of variant dicts to sweep over. Each dict is exposed
+        as attributes on ctx.variant.
     num_iterations : int
-        Number of times to repeat each variation. Controls the iter_<N>
-        subfolders under each variation directory.
+        Number of times to repeat each variant. Controls the iter_<N>
+        subfolders under each variant directory.
     """
 
     def decorator(fn):

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -22,6 +22,7 @@ pair.
 
 """
 
+import functools
 import inspect
 import sys
 
@@ -59,6 +60,7 @@ def benchmark(variants, num_iterations):
     """
 
     def decorator(fn):
+        @functools.wraps(fn)
         def wrapper(args=None):
             cli_args = sys.argv[1:] if args is None else args
             options = _parse_options(fn, cli_args)

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -61,7 +61,7 @@ def benchmark(variants, num_iterations):
 
     def decorator(fn):
         @functools.wraps(fn)
-        def wrapper(args=None):
+        def wrapper(args=None, output_dir=None):
             cli_args = sys.argv[1:] if args is None else args
             options = _parse_options(fn, cli_args)
             source = Source(path=inspect.getfile(fn))
@@ -70,9 +70,7 @@ def benchmark(variants, num_iterations):
                     ctx = Context(
                         variant=variant,
                         iteration=iteration,
-                        output_dir=".",
-                        # TODO(teresa-ortega): change the output_dir
-                        # implementation.
+                        output_dir=output_dir,
                         options=options,
                         source=source,
                         variant_index=variant_index,

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -13,3 +13,57 @@
 # limitations under the License.
 
 """Benchmark loop decorator for lambkin."""
+
+import sys
+
+import click
+
+from lambkin.core.ctx.context import Context
+from lambkin.core.ctx.source import Source
+
+
+def _parse_options(fn):
+    """Parse CLI options from fn.__lambkin_options__ and return a dict."""
+    registered = getattr(fn, "__lambkin_options__", [])
+    if not registered:
+        return {}
+    cmd = click.Command(name="benchmark", params=registered)
+    click_ctx = cmd.make_context("benchmark", sys.argv[1:], allow_extra_args=True)
+    return click_ctx.params
+
+
+def benchmark(variants, num_iterations):
+    """Drive the benchmark execution loop over all variants and iterations.
+
+    Parses CLI options registered by @lambkin.option once before the loop,
+    then creates a Context for each (variation, iteration) pair and calls
+    the decorated function with it.
+
+    Parameters
+    ----------
+    variants : iterable of dict
+        Sequence of variation dicts to sweep over. Each dict is exposed
+        as attributes on ctx.variation.
+    num_iterations : int
+        Number of times to repeat each variation. Controls the iter_<N>
+        subfolders under each variation directory.
+    """
+
+    def decorator(fn):
+        def wrapper():
+            options = _parse_options(fn)
+            source = Source(path=fn.__code__.co_filename)
+            for variation_index, variation in enumerate(variants):
+                for iteration in range(num_iterations):
+                    ctx = Context(
+                        variation=variation,
+                        iteration=iteration,
+                        options=options,
+                        source=source,
+                        variation_index=variation_index,
+                    )
+                    fn(ctx)
+
+        return wrapper
+
+    return decorator

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -70,10 +70,10 @@ def benchmark(variants, num_iterations):
                     ctx = Context(
                         variant=variant,
                         iteration=iteration,
-                        output_dir=output_dir,
                         options=options,
                         source=source,
                         variant_index=variant_index,
+                        output_dir=output_dir,
                     )
                     fn(ctx)
 

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -19,7 +19,7 @@ variants and iterations. It collects CLI option definitions registered by
 @option, parses them once before the loop using an internal click parser, and
 injects the resulting values into a Context class on each (variant, iteration)
 pair.
-
+Raises ValueError if variants is empty.
 """
 
 import functools
@@ -57,6 +57,11 @@ def benchmark(variants, num_iterations):
     num_iterations : int
         Number of times to repeat each variant. Controls the iter_<N>
         subfolders under each variant directory.
+
+    Raises:
+    ------
+    ValueError
+        If variants is empty
     """
     if not variants:
         raise ValueError(

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -36,7 +36,7 @@ def benchmark(variants, num_iterations):
     """Drive the benchmark execution loop over all variants and iterations.
 
     Parses CLI options registered by @lambkin.option once before the loop,
-    then creates a Context for each (variation, iteration) pair and calls
+    then creates a Context for each (variants, iteration) pair and calls
     the decorated function with it.
 
     Parameters
@@ -58,6 +58,7 @@ def benchmark(variants, num_iterations):
                     ctx = Context(
                         variation=variation,
                         iteration=iteration,
+                        output_dir=".",
                         options=options,
                         source=source,
                         variation_index=variation_index,

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -58,6 +58,11 @@ def benchmark(variants, num_iterations):
         Number of times to repeat each variant. Controls the iter_<N>
         subfolders under each variant directory.
     """
+    if not variants:
+        raise ValueError(
+            "You have provided an empty variants list; therefore, no "
+            "benchmarking iterations will be executed."
+        )
 
     def decorator(fn):
         @functools.wraps(fn)

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -63,19 +63,17 @@ def benchmark(variants, num_iterations):
             cli_args = sys.argv[1:] if args is None else args
             options = _parse_options(fn, cli_args)
             source = Source(path=inspect.getfile(fn))
-            for variation_index, variation in enumerate(variants):
+            for variant_index, variant in enumerate(variants):
                 for iteration in range(num_iterations):
                     ctx = Context(
-                        # TODO(teresa-ortega): change the name variation.
-                        # variation-> variant.
-                        variation=variation,
+                        variant=variant,
                         iteration=iteration,
                         output_dir=".",
                         # TODO(teresa-ortega): change the output_dir
                         # implementation.
                         options=options,
                         source=source,
-                        variation_index=variation_index,
+                        variant_index=variant_index,
                     )
                     fn(ctx)
 

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -163,3 +163,17 @@ def test_benchmark_default_output_dir_uses_source_path(variants, tmp_path):
 
     assert contexts[0].output.base_dir == tmp_path / Context.BENCHMARKS_DIRNAME
     assert contexts[0].source.path == fake_script
+
+
+def test_benchmark_empty_variants_raises_error(tmp_path):
+    """Calling a benchmark with an empty variants list raises an exception."""
+    expected_message = (
+        "You have provided an empty variants list; therefore, no "
+        "benchmarking iterations will be executed."
+    )
+
+    with pytest.raises(ValueError, match=expected_message):
+
+        @benchmark(variants=[], num_iterations=1)
+        def fn(ctx):
+            pass

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -117,3 +117,16 @@ def test_benchmark_source_path_points_to_benchmark_script(variants):
 
     fn()
     assert contexts[0].source.path == Path(__file__)
+
+
+def test_benchmark_options_injected_via_args(variants):
+    """CLI args passed explicitly to wrapper() override decorator defaults."""
+    contexts = []
+
+    @benchmark(variants=variants, num_iterations=1)
+    @option("--clock-rate", default=100.0)
+    def fn(ctx):
+        contexts.append(ctx)
+
+    fn(args=["--clock-rate", "50.0"])
+    assert contexts[0].options.clock_rate == 50.0

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the benchmark decorator in lambkin.core.decorators."""
+
+from pathlib import Path
+
+import pytest
+
+from lambkin.core.decorators.benchmark import benchmark
+from lambkin.core.decorators.option import option
+
+
+@pytest.fixture
+def variants():
+    """Base variants for testing."""
+    return [
+        {"sensor_model": "beam", "num_particles": 10},
+        {"sensor_model": "likelihood", "num_particles": 100},
+    ]
+
+
+def test_benchmark_loops_over_variants_and_iterations(variants):
+    """Benchmark calls fn once per (variation, iteration) pair."""
+    calls = []
+
+    @benchmark(variants=variants, num_iterations=3)
+    def fn(ctx):
+        calls.append(ctx)
+
+    fn()
+    assert len(calls) == 6
+
+
+def test_benchmark_variation_attributes_are_correct(variants):
+    """ctx.variation exposes the variant dict as attributes."""
+    contexts = []
+
+    @benchmark(variants=variants, num_iterations=1)
+    def fn(ctx):
+        contexts.append(ctx)
+
+    fn()
+    assert contexts[0].variation.sensor_model == "beam"
+    assert contexts[0].variation.num_particles == 10
+    assert contexts[1].variation.sensor_model == "likelihood"
+    assert contexts[1].variation.num_particles == 100
+
+
+def test_benchmark_options_defaults_injected(variants):
+    """Default option values are injected into ctx.options."""
+    contexts = []
+
+    @benchmark(variants=variants, num_iterations=1)
+    @option("--clock-rate", default=100.0)
+    @option("--sensor-topic", default="/scan")
+    def fn(ctx):
+        contexts.append(ctx)
+
+    fn()
+    assert contexts[0].options.clock_rate == 100.0
+    assert contexts[0].options.sensor_topic == "/scan"
+
+
+def test_benchmark_source_path_points_to_benchmark_script(variants):
+    """Source.path points to the file where the benchmark function is defined."""
+    contexts = []
+
+    @benchmark(variants=variants, num_iterations=1)
+    def fn(ctx):
+        contexts.append(ctx)
+
+    fn()
+    assert contexts[0].source.path == Path(__file__)

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -15,9 +15,12 @@
 """Unit tests for the benchmark decorator in lambkin.core.decorators."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+from lambkin.core.ctx.context import Context
+from lambkin.core.ctx.source import Source
 from lambkin.core.decorators.benchmark import _parse_options, benchmark
 from lambkin.core.decorators.option import option
 
@@ -65,7 +68,19 @@ def test_parse_options_returns_cli_values_when_provided():
     assert result == {"clock_rate": 50.0, "sensor_topic": "/scan"}
 
 
-def test_benchmark_loops_over_variants_and_iterations(variants):
+def test_benchmark_preserves_metadata(variants, tmp_path):
+    """@benchmark preserves the decorated function's name and docstring."""
+
+    @benchmark(variants=variants, num_iterations=1)
+    def my_cool_benchmark(ctx):
+        """Standard docstring."""
+        pass
+
+    assert my_cool_benchmark.__name__ == "my_cool_benchmark"
+    assert my_cool_benchmark.__doc__ == "Standard docstring."
+
+
+def test_benchmark_loops_over_variants_and_iterations(variants, tmp_path):
     """Benchmark calls fn once per (variant, iteration) pair."""
     calls = []
 
@@ -73,11 +88,11 @@ def test_benchmark_loops_over_variants_and_iterations(variants):
     def fn(ctx):
         calls.append(ctx)
 
-    fn()
+    fn(output_dir=tmp_path)
     assert len(calls) == 6
 
 
-def test_benchmark_variant_attributes_are_correct(variants):
+def test_benchmark_variant_attributes_are_correct(variants, tmp_path):
     """ctx.variant exposes the variant dict as attributes."""
     contexts = []
 
@@ -85,14 +100,14 @@ def test_benchmark_variant_attributes_are_correct(variants):
     def fn(ctx):
         contexts.append(ctx)
 
-    fn()
+    fn(output_dir=tmp_path)
     assert contexts[0].variant.sensor_model == "beam"
     assert contexts[0].variant.num_particles == 10
     assert contexts[1].variant.sensor_model == "likelihood"
     assert contexts[1].variant.num_particles == 100
 
 
-def test_benchmark_options_defaults_injected(variants):
+def test_benchmark_options_defaults_injected(variants, tmp_path):
     """Default option values are injected into ctx.options."""
     contexts = []
 
@@ -102,24 +117,12 @@ def test_benchmark_options_defaults_injected(variants):
     def fn(ctx):
         contexts.append(ctx)
 
-    fn()
+    fn(output_dir=tmp_path)
     assert contexts[0].options.clock_rate == 100.0
     assert contexts[0].options.sensor_topic == "/scan"
 
 
-def test_benchmark_source_path_points_to_benchmark_script(variants):
-    """Source.path points to the file where the benchmark function is defined."""
-    contexts = []
-
-    @benchmark(variants=variants, num_iterations=1)
-    def fn(ctx):
-        contexts.append(ctx)
-
-    fn()
-    assert contexts[0].source.path == Path(__file__)
-
-
-def test_benchmark_options_injected_via_args(variants):
+def test_benchmark_options_injected_via_args(variants, tmp_path):
     """CLI args passed explicitly to wrapper() override decorator defaults."""
     contexts = []
 
@@ -128,5 +131,35 @@ def test_benchmark_options_injected_via_args(variants):
     def fn(ctx):
         contexts.append(ctx)
 
-    fn(args=["--clock-rate", "50.0"])
+    fn(args=["--clock-rate", "50.0"], output_dir=tmp_path)
     assert contexts[0].options.clock_rate == 50.0
+
+
+def test_benchmark_source_path_points_to_benchmark_script(variants, tmp_path):
+    """Source.path points to the file where the benchmark function is defined."""
+    contexts = []
+
+    @benchmark(variants=variants, num_iterations=1)
+    def fn(ctx):
+        contexts.append(ctx)
+
+    fn(output_dir=tmp_path)
+    assert contexts[0].source.path == Path(__file__)
+
+
+def test_benchmark_default_output_dir_uses_source_path(variants, tmp_path):
+    """When output_dir=None, output is resolved relative to the source path."""
+    contexts = []
+    fake_script = tmp_path / "my_benchmark.py"
+    fake_script.touch()
+    fake_source = Source(path=fake_script)
+
+    @benchmark(variants=variants, num_iterations=1)
+    def fn(ctx):
+        contexts.append(ctx)
+
+    with patch("lambkin.core.decorators.benchmark.Source", return_value=fake_source):
+        fn()
+
+    assert contexts[0].output.base_dir == tmp_path / Context.BENCHMARKS_DIRNAME
+    assert contexts[0].source.path == fake_script

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -66,7 +66,7 @@ def test_parse_options_returns_cli_values_when_provided():
 
 
 def test_benchmark_loops_over_variants_and_iterations(variants):
-    """Benchmark calls fn once per (variation, iteration) pair."""
+    """Benchmark calls fn once per (variant, iteration) pair."""
     calls = []
 
     @benchmark(variants=variants, num_iterations=3)
@@ -77,8 +77,8 @@ def test_benchmark_loops_over_variants_and_iterations(variants):
     assert len(calls) == 6
 
 
-def test_benchmark_variation_attributes_are_correct(variants):
-    """ctx.variation exposes the variant dict as attributes."""
+def test_benchmark_variant_attributes_are_correct(variants):
+    """ctx.variant exposes the variant dict as attributes."""
     contexts = []
 
     @benchmark(variants=variants, num_iterations=1)
@@ -86,10 +86,10 @@ def test_benchmark_variation_attributes_are_correct(variants):
         contexts.append(ctx)
 
     fn()
-    assert contexts[0].variation.sensor_model == "beam"
-    assert contexts[0].variation.num_particles == 10
-    assert contexts[1].variation.sensor_model == "likelihood"
-    assert contexts[1].variation.num_particles == 100
+    assert contexts[0].variant.sensor_model == "beam"
+    assert contexts[0].variant.num_particles == 10
+    assert contexts[1].variant.sensor_model == "likelihood"
+    assert contexts[1].variant.num_particles == 100
 
 
 def test_benchmark_options_defaults_injected(variants):

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from lambkin.core.decorators.benchmark import benchmark
+from lambkin.core.decorators.benchmark import _parse_options, benchmark
 from lambkin.core.decorators.option import option
 
 
@@ -29,6 +29,40 @@ def variants():
         {"sensor_model": "beam", "num_particles": 10},
         {"sensor_model": "likelihood", "num_particles": 100},
     ]
+
+
+def test_parse_options_returns_empty_dict_when_no_options():
+    """_parse_options returns empty dict when fn has no __lambkin_options__."""
+
+    def fn(ctx):
+        pass
+
+    result = _parse_options(fn, [])
+    assert result == {}
+
+
+def test_parse_options_returns_defaults_when_no_args():
+    """_parse_options returns default values when no CLI args are provided."""
+
+    @option("--clock-rate", default=100.0)
+    @option("--sensor-topic", default="/scan")
+    def fn(ctx):
+        pass
+
+    result = _parse_options(fn, [])
+    assert result == {"clock_rate": 100.0, "sensor_topic": "/scan"}
+
+
+def test_parse_options_returns_cli_values_when_provided():
+    """_parse_options returns CLI values when args are provided."""
+
+    @option("--clock-rate", default=100.0)
+    @option("--sensor-topic", default="/scan")
+    def fn(ctx):
+        pass
+
+    result = _parse_options(fn, ["--clock-rate", "50.0"])
+    assert result == {"clock_rate": 50.0, "sensor_topic": "/scan"}
 
 
 def test_benchmark_loops_over_variants_and_iterations(variants):


### PR DESCRIPTION
### Proposed changes

Adds the `benchmark` decorator, which orchestrates the benchmark execution loop. It parses CLI options registered by @lambkin.option once before the loop using an internal click parser, then creates a fresh Context for each (variant, iteration) pair, injecting the parsed options, the source inferred from the script path, and the variant index.

CLI options are parsed once and reused across all iterations to avoid redundant parsing.

Relates to:
- #136 
- #137

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes.

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Additional comments

N/A