### PR TITLE
Phase 3: core/decorators/input

### DIFF
--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -30,6 +30,7 @@ import click
 
 from lambkin.core.ctx.context import Context
 from lambkin.core.ctx.source import Source
+from lambkin.core.decorators.input import InputRegistry
 
 
 def _parse_options(fn, cli_args):
@@ -70,6 +71,8 @@ def benchmark(variants, num_iterations):
         )
 
     def decorator(fn):
+        inputs = InputRegistry()
+
         @functools.wraps(fn)
         def wrapper(args=None, output_dir=None):
             cli_args = sys.argv[1:] if args is None else args
@@ -85,8 +88,10 @@ def benchmark(variants, num_iterations):
                         variant_index=variant_index,
                         output_dir=output_dir,
                     )
+                    inputs.resolve(ctx)
                     fn(ctx)
 
+        wrapper.input = inputs.register
         return wrapper
 
     return decorator

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -19,6 +19,11 @@ variants and iterations. It collects CLI option definitions registered by
 @option, parses them once before the loop using an internal click parser, and
 injects the resulting values into a Context class on each (variant, iteration)
 pair.
+
+Input hooks registered via "@nominal.input" are managed by "InputRegistry"
+instance and resolved before the benchmark function runs on each iteration,
+injecting their return values into "ctx.inputs".
+
 Raises ValueError if variants is empty.
 """
 
@@ -46,18 +51,19 @@ def _parse_options(fn, cli_args):
 def benchmark(variants, num_iterations):
     """Drive the benchmark execution loop over all variants and iterations.
 
-    Parses CLI options registered by @lambkin.option once before the loop,
-    then creates a Context for each (variant, iteration) pair and calls
-    the decorated function with it.
+    Parses CLI options registered by @lambkin.option once before the loop, then
+    creates a Context for each (variant, iteration) pair and calls the decorated
+    function with it. Input hooks registered via @nominal.input are resolved
+    before each call, injecting their return values into ctx.inputs.
 
     Parameters
     ----------
     variants : iterable of dict
-        Sequence of variant dicts to sweep over. Each dict is exposed
-        as attributes on ctx.variant.
+        Sequence of variant dicts to sweep over. Each dict is exposed as
+        attributes on ctx.variant.
     num_iterations : int
-        Number of times to repeat each variant. Controls the iter_<N>
-        subfolders under each variant directory.
+        Number of times to repeat each variant. Controls the iter_<N> subfolders
+        under each variant directory.
 
     Raises:
     ------

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -84,6 +84,16 @@ def benchmark(variants, num_iterations):
             cli_args = sys.argv[1:] if args is None else args
             options = _parse_options(fn, cli_args)
             source = Source(path=inspect.getfile(fn))
+            base_ctx = Context(
+                variant={},
+                iteration=0,
+                options=options,
+                source=source,
+                variant_index=0,
+                output_dir=output_dir,
+            )
+            inputs.resolve(base_ctx)
+            resolved_inputs = base_ctx.inputs
             for variant_index, variant in enumerate(variants):
                 for iteration in range(num_iterations):
                     ctx = Context(
@@ -94,7 +104,7 @@ def benchmark(variants, num_iterations):
                         variant_index=variant_index,
                         output_dir=output_dir,
                     )
-                    inputs.resolve(ctx)
+                    ctx.inputs = resolved_inputs
                     fn(ctx)
 
         wrapper.input = inputs.register

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -20,6 +20,8 @@ resolution of input hooks for a benchmark function. Hooks are registered via the
 injecting their return values into "ctx.inputs" under the hook's function name.
 """
 
+import inspect
+
 
 class InputRegistryError(Exception):
     """Raised when a critical input registry error occurs."""
@@ -30,13 +32,21 @@ class InputRegistryError(Exception):
 def _validate_result(hook_fn, result) -> None:
     """Validate the return value of a hook function."""
     if result is None:
-        raise InputRegistryError(
+        raise ValueError(
             f"Hook '{hook_fn.__name__}' returned None or did not return a value."
         )
     if isinstance(result, str) and not result.strip():
-        raise InputRegistryError(
+        raise ValueError(
             f"Hook '{hook_fn.__name__}' returned an empty or blank string."
         )
+
+
+def _validate_hook_signature(hook_fn) -> None:
+    """Validate that the hook function accepts a single 'ctx' parameter."""
+    params = list(inspect.signature(hook_fn).parameters.keys())
+
+    if len(params) != 1:
+        raise ValueError(f"Hook '{hook_fn.__name__}' must have exactly 1 parameter, ")
 
 
 class InputRegistry:
@@ -50,7 +60,7 @@ class InputRegistry:
         """Decorator used to register a function as an input provider."""
         existing_names = [h.__name__ for h in self._hooks]
         if hook_fn.__name__ in existing_names:
-            raise InputRegistryError(
+            raise ValueError(
                 f"Hook name conflict: '{hook_fn.__name__}' is already registered."
             )
         self._hooks.append(hook_fn)
@@ -59,6 +69,7 @@ class InputRegistry:
     def resolve(self, ctx):
         """Resolve all registered input hooks."""
         for hook in self._hooks:
+            _validate_hook_signature(hook)
             result = hook(ctx)
             _validate_result(hook, result)
             setattr(ctx.inputs, hook.__name__, result)

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -40,7 +40,7 @@ def _validate_hook_signature(hook_fn) -> None:
     params = list(inspect.signature(hook_fn).parameters.keys())
 
     if len(params) != 1:
-        raise ValueError(f"Hook '{hook_fn.__name__}' must have exactly 1 parameter, ")
+        raise ValueError(f"Hook '{hook_fn.__name__}' must have exactly 1 parameter.")
 
 
 class InputRegistry:

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Input decorator for lambkin."""
+"""Input decorator for lambkin.
+
+Provides the class "InputRegistry" class, which manages the registration and
+resolution of input hooks for a benchmark function. Hooks are registered via the
+"InputRegistry.register" method and resolved before the benchmark function runs,
+injecting their return values into "ctx.inputs" under the hook's function name.
+"""
 
 
 class InputRegistry:

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -23,12 +23,6 @@ injecting their return values into "ctx.inputs" under the hook's function name.
 import inspect
 
 
-class InputRegistryError(Exception):
-    """Raised when a critical input registry error occurs."""
-
-    pass
-
-
 def _validate_result(hook_fn, result) -> None:
     """Validate the return value of a hook function."""
     if result is None:

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -52,6 +52,7 @@ class InputRegistry:
 
     def register(self, hook_fn):
         """Decorator used to register a function as an input provider."""
+        _validate_hook_signature(hook_fn)
         existing_names = [h.__name__ for h in self._hooks]
         if hook_fn.__name__ in existing_names:
             raise ValueError(
@@ -63,7 +64,6 @@ class InputRegistry:
     def resolve(self, ctx):
         """Resolve all registered input hooks."""
         for hook in self._hooks:
-            _validate_hook_signature(hook)
             result = hook(ctx)
             _validate_result(hook, result)
             setattr(ctx.inputs, hook.__name__, result)

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -44,14 +44,26 @@ def _validate_hook_signature(hook_fn) -> None:
 
 
 class InputRegistry:
-    """Manages the registration and resolution of input hooks for a benchmark."""
+    """Manages the registration and resolution of input hooks for a benchmark.
+
+    Warning:
+       Hooks are resolved with a base context containing dummy variant and
+       iteration values. Accessing ctx.variant or ctx.iteration inside a hook
+       will silently return empty/wrong values. Hooks should only depend on
+       ctx.options or other stable context fields.
+    """
 
     def __init__(self):
         """Initialize the InputRegistry."""
         self._hooks = []
 
     def register(self, hook_fn):
-        """Decorator used to register a function as an input provider."""
+        """Decorator used to register a function as an input provider.
+
+        Warning: Do not access ctx.variant or ctx.iteration inside the hook,
+        they will contain dummy values at resolve time, leading to silent bugs
+        that are hard to trace.
+        """
         _validate_hook_signature(hook_fn)
         existing_names = [h.__name__ for h in self._hooks]
         if hook_fn.__name__ in existing_names:

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -13,3 +13,30 @@
 # limitations under the License.
 
 """Input decorator for lambkin."""
+
+import functools
+
+
+def input(hook):
+    """Wrap a benchmark function to inject an input into ``ctx.inputs``.
+
+    Uses :func:`inspect.getfile` to read the hook name and injects
+    the return value into ``ctx.inputs.<name>`` before the benchmark runs.
+
+    Parameters
+    ----------
+    hook : callable
+        Input resolver function. Must accept a single ``ctx`` argument
+        and return the input value to inject into ``ctx.inputs``.
+    """
+
+    def decorator(benchmark_fn):
+        @functools.wraps(benchmark_fn)
+        def wrapper(ctx):
+            setattr(ctx.inputs, hook.__name__, hook(ctx))
+            return benchmark_fn(ctx)
+
+        wrapper.__wrapped__ = benchmark_fn
+        return wrapper
+
+    return decorator

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -21,6 +21,24 @@ injecting their return values into "ctx.inputs" under the hook's function name.
 """
 
 
+class InputRegistryError(Exception):
+    """Raised when a critical input registry error occurs."""
+
+    pass
+
+
+def _validate_result(hook_fn, result) -> None:
+    """Validate the return value of a hook function."""
+    if result is None:
+        raise InputRegistryError(
+            f"Hook '{hook_fn.__name__}' returned None or did not return a value."
+        )
+    if isinstance(result, str) and not result.strip():
+        raise InputRegistryError(
+            f"Hook '{hook_fn.__name__}' returned an empty or blank string."
+        )
+
+
 class InputRegistry:
     """Manages the registration and resolution of input hooks for a benchmark."""
 
@@ -30,15 +48,17 @@ class InputRegistry:
 
     def register(self, hook_fn):
         """Decorator used to register a function as an input provider."""
+        existing_names = [h.__name__ for h in self._hooks]
+        if hook_fn.__name__ in existing_names:
+            raise InputRegistryError(
+                f"Hook name conflict: '{hook_fn.__name__}' is already registered."
+            )
         self._hooks.append(hook_fn)
         return hook_fn
 
     def resolve(self, ctx):
-        """Resolve all registered input hooks.
-
-        Executes all registered hooks and dynamically maps their return values
-        to the "ctx.inputs" namespace using the original function's name.
-        """
+        """Resolve all registered input hooks."""
         for hook in self._hooks:
             result = hook(ctx)
+            _validate_result(hook, result)
             setattr(ctx.inputs, hook.__name__, result)

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -14,29 +14,25 @@
 
 """Input decorator for lambkin."""
 
-import functools
 
+class InputRegistry:
+    """Manages the registration and resolution of input hooks for a benchmark."""
 
-def input(hook):
-    """Wrap a benchmark function to inject an input into ``ctx.inputs``.
+    def __init__(self):
+        """Initialize the InputRegistry."""
+        self._hooks = []
 
-    Uses :func:`inspect.getfile` to read the hook name and injects
-    the return value into ``ctx.inputs.<name>`` before the benchmark runs.
+    def register(self, hook_fn):
+        """Decorator used to register a function as an input provider."""
+        self._hooks.append(hook_fn)
+        return hook_fn
 
-    Parameters
-    ----------
-    hook : callable
-        Input resolver function. Must accept a single ``ctx`` argument
-        and return the input value to inject into ``ctx.inputs``.
-    """
+    def resolve(self, ctx):
+        """Resolve all registered input hooks.
 
-    def decorator(benchmark_fn):
-        @functools.wraps(benchmark_fn)
-        def wrapper(ctx):
-            setattr(ctx.inputs, hook.__name__, hook(ctx))
-            return benchmark_fn(ctx)
-
-        wrapper.__wrapped__ = benchmark_fn
-        return wrapper
-
-    return decorator
+        Executes all registered hooks and dynamically maps their return values
+        to the "ctx.inputs" namespace using the original function's name.
+        """
+        for hook in self._hooks:
+            result = hook(ctx)
+            setattr(ctx.inputs, hook.__name__, result)

--- a/test/core/test_input.py
+++ b/test/core/test_input.py
@@ -16,6 +16,7 @@
 
 import pytest
 
+from lambkin.core.ctx import Context
 from lambkin.core.decorators.benchmark import benchmark
 from lambkin.core.decorators.input import InputRegistry
 
@@ -49,20 +50,82 @@ def test_registered_hook_name_is_preserved():
     assert registry._hooks[0].__name__ == "my_dataset"
 
 
-def test_two_hooks_registered_in_order():
-    """Hooks are stored in registration order."""
+def test_hook_with_no_parameters_raises():
+    """A hook with no parameters raises ValueError at resolve time."""
     registry = InputRegistry()
+    ctx = Context.__new__(Context)
+
+    def bad_hook():
+        return "value"
+
+    registry.register(bad_hook)
+    with pytest.raises(ValueError, match="exactly 1 parameter"):
+        registry.resolve(ctx)
+
+
+def test_hook_with_extra_parameters_raises():
+    """A hook with more than 1 parameter raises ValueError at resolve time."""
+    registry = InputRegistry()
+    ctx = Context.__new__(Context)
+
+    def bad_hook(ctx, extra):
+        return "value"
+
+    registry.register(bad_hook)
+    with pytest.raises(ValueError, match="exactly 1 parameter"):
+        registry.resolve(ctx)
+
+
+def test_hook_returning_none_raises():
+    """A hook that returns None raises ValueError."""
+    registry = InputRegistry()
+    ctx = Context.__new__(Context)
 
     def dataset(ctx):
-        return "d"
-
-    def map(ctx):
-        return "m"
+        return None
 
     registry.register(dataset)
-    registry.register(map)
+    with pytest.raises(ValueError, match="None"):
+        registry.resolve(ctx)
 
-    assert [h.__name__ for h in registry._hooks] == ["dataset", "map"]
+
+def test_hook_with_no_return_raises():
+    """A hook with no return statement raises ValueError."""
+    registry = InputRegistry()
+    ctx = Context.__new__(Context)
+
+    def dataset(ctx):
+        pass
+
+    registry.register(dataset)
+    with pytest.raises(ValueError, match="None"):
+        registry.resolve(ctx)
+
+
+def test_hook_returning_empty_string_raises():
+    """A hook that returns an empty string raises ValueError."""
+    registry = InputRegistry()
+    ctx = Context.__new__(Context)
+
+    def dataset(ctx):
+        return ""
+
+    registry.register(dataset)
+    with pytest.raises(ValueError, match="empty"):
+        registry.resolve(ctx)
+
+
+def test_hook_returning_blank_string_raises():
+    """A hook that returns a whitespace-only string raises ValueError."""
+    registry = InputRegistry()
+    ctx = Context.__new__(Context)
+
+    def dataset(ctx):
+        return "   "
+
+    registry.register(dataset)
+    with pytest.raises(ValueError, match="empty"):
+        registry.resolve(ctx)
 
 
 def test_ctx_inputs_populated_before_fn_runs(variant):

--- a/test/core/test_input.py
+++ b/test/core/test_input.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the input decorator in lambkin.core.decorators."""
+
+import pytest
+
+from lambkin.core.decorators.benchmark import benchmark
+from lambkin.core.decorators.input import InputRegistry
+
+
+@pytest.fixture
+def variant():
+    """Base variants for testing."""
+    return [
+        {"sensor_model": "beam", "num_particles": 10},
+    ]
+
+
+def test_register_returns_original_function():
+    """register() returns the original function unchanged."""
+    registry = InputRegistry()
+
+    def dataset(ctx):
+        return "data.mcap"
+
+    assert registry.register(dataset) is dataset
+
+
+def test_registered_hook_name_is_preserved():
+    """The ctx.inputs attribute name is the hook's __name__."""
+    registry = InputRegistry()
+
+    def my_dataset(ctx):
+        return "x"
+
+    registry.register(my_dataset)
+    assert registry._hooks[0].__name__ == "my_dataset"
+
+
+def test_two_hooks_registered_in_order():
+    """Hooks are stored in registration order."""
+    registry = InputRegistry()
+
+    def dataset(ctx):
+        return "d"
+
+    def map(ctx):
+        return "m"
+
+    registry.register(dataset)
+    registry.register(map)
+
+    assert [h.__name__ for h in registry._hooks] == ["dataset", "map"]
+
+
+def test_ctx_inputs_populated_before_fn_runs(variant):
+    """ctx.inputs.dataset is available inside the benchmark function after resolve."""
+    seen = []
+
+    @benchmark(variants=variant, num_iterations=1)
+    def nominal(ctx):
+        seen.append(ctx.inputs.dataset)
+
+    @nominal.input
+    def dataset(ctx):
+        return "path/to/dataset.mcap"
+
+    nominal(output_dir="/tmp")
+    assert seen == ["path/to/dataset.mcap"]
+
+
+def test_multiple_inputs_all_injected(variant):
+    """All registered inputs are injected into ctx.inputs before the benchmark runs."""
+    seen = []
+
+    @benchmark(variants=variant, num_iterations=1)
+    def nominal(ctx):
+        seen.append((ctx.inputs.dataset, ctx.inputs.map))
+
+    @nominal.input
+    def dataset(ctx):
+        return "path/to/dataset.mcap"
+
+    @nominal.input
+    def map(ctx):
+        return "path/to/map.yaml"
+
+    nominal(output_dir="/tmp")
+    assert seen == [("path/to/dataset.mcap", "path/to/map.yaml")]
+
+
+def test_inputs_resolved_on_every_iteration(variant):
+    """resolve() must run once per iteration, not just once upfront."""
+    call_count = [0]
+    seen = []
+
+    @benchmark(variants=variant, num_iterations=3)
+    def nominal(ctx):
+        seen.append(ctx.inputs.counter)
+
+    @nominal.input
+    def counter(ctx):
+        call_count[0] += 1
+        return call_count[0]
+
+    nominal(output_dir="/tmp")
+
+    assert seen == [1, 2, 3]

--- a/test/core/test_input.py
+++ b/test/core/test_input.py
@@ -53,27 +53,23 @@ def test_registered_hook_name_is_preserved():
 def test_hook_with_no_parameters_raises():
     """A hook with no parameters raises ValueError at resolve time."""
     registry = InputRegistry()
-    ctx = Context.__new__(Context)
 
     def bad_hook():
         return "value"
 
-    registry.register(bad_hook)
     with pytest.raises(ValueError, match="exactly 1 parameter."):
-        registry.resolve(ctx)
+        registry.register(bad_hook)
 
 
 def test_hook_with_extra_parameters_raises():
     """A hook with more than 1 parameter raises ValueError at resolve time."""
     registry = InputRegistry()
-    ctx = Context.__new__(Context)
 
     def bad_hook(ctx, extra):
         return "value"
 
-    registry.register(bad_hook)
     with pytest.raises(ValueError, match="exactly 1 parameter."):
-        registry.resolve(ctx)
+        registry.register(bad_hook)
 
 
 def test_hook_returning_none_raises():

--- a/test/core/test_input.py
+++ b/test/core/test_input.py
@@ -99,22 +99,3 @@ def test_multiple_inputs_all_injected(variant):
 
     nominal(output_dir="/tmp")
     assert seen == [("path/to/dataset.mcap", "path/to/map.yaml")]
-
-
-def test_inputs_resolved_on_every_iteration(variant):
-    """resolve() must run once per iteration, not just once upfront."""
-    call_count = [0]
-    seen = []
-
-    @benchmark(variants=variant, num_iterations=3)
-    def nominal(ctx):
-        seen.append(ctx.inputs.counter)
-
-    @nominal.input
-    def counter(ctx):
-        call_count[0] += 1
-        return call_count[0]
-
-    nominal(output_dir="/tmp")
-
-    assert seen == [1, 2, 3]

--- a/test/core/test_input.py
+++ b/test/core/test_input.py
@@ -158,3 +158,28 @@ def test_multiple_inputs_all_injected(variant):
 
     nominal(output_dir="/tmp")
     assert seen == [("path/to/dataset.mcap", "path/to/map.yaml")]
+
+
+def test_input_hook_called_once_regardless_of_variants_and_iterations():
+    """Input hooks are resolved once, regardless of variants and iterations."""
+    call_count = 0
+
+    @benchmark(
+        variants=[
+            {"sensor_model": "beam", "num_particles": 10},
+            {"sensor_model": "lidar", "num_particles": 20},
+        ],
+        num_iterations=3,
+    )
+    def nominal(ctx):
+        pass
+
+    @nominal.input
+    def dataset(ctx):
+        nonlocal call_count
+        call_count += 1
+        return "path/to/dataset.mcap"
+
+    nominal(output_dir="/tmp")
+
+    assert call_count == 1

--- a/test/core/test_input.py
+++ b/test/core/test_input.py
@@ -59,7 +59,7 @@ def test_hook_with_no_parameters_raises():
         return "value"
 
     registry.register(bad_hook)
-    with pytest.raises(ValueError, match="exactly 1 parameter"):
+    with pytest.raises(ValueError, match="exactly 1 parameter."):
         registry.resolve(ctx)
 
 
@@ -72,7 +72,7 @@ def test_hook_with_extra_parameters_raises():
         return "value"
 
     registry.register(bad_hook)
-    with pytest.raises(ValueError, match="exactly 1 parameter"):
+    with pytest.raises(ValueError, match="exactly 1 parameter."):
         registry.resolve(ctx)
 
 


### PR DESCRIPTION
### Proposed changes

This PR introduces a dynamic input registration system for benchmarks using a functional hook pattern. To keep the core benchmark decorator clean and maintain a strict separation of concerns, the registration logic was extracted into a dedicated InputRegistry. The decorated benchmark function now dynamically exposes an .input method, allowing users to register input hooks. 
Additionally, the benchmark context was updated. At runtime, right before the main benchmark executes, these registered hooks are evaluated with the actual context, and their return values are automatically mapped to the context inputs based on the function names.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes.

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Additional comments

N/A
