### PR TITLE
Phase 3: core/shell/proxy

### DIFF
--- a/examples/beluga/beluga_benchmark.py
+++ b/examples/beluga/beluga_benchmark.py
@@ -24,7 +24,7 @@ import lambkin
 )
 @lambkin.option("--clock-rate", default=100.0)
 @lambkin.option("--sensor-topic", default="/scan")
-@lambkin.option("--dry-run", default=False)
+@lambkin.option("--dry-run", default=True)
 def nominal(ctx):
     """Run a nominal Beluga AMCL benchmark across sensor models and particle counts.
 

--- a/examples/beluga/beluga_benchmark.py
+++ b/examples/beluga/beluga_benchmark.py
@@ -40,7 +40,6 @@ def nominal(ctx):
     print(f"sensor_topic: {ctx.options.sensor_topic}")
     print(f"source: {ctx.source}")
     print("---")
-    ctx.shell = lambkin.ShellProxy(dry_run=ctx.options.dry_run)
     ctx.shell.ros2.launch(
         ctx.source.path.parent / "beluga.launch.xml",
         f"sensor_model:={ctx.variant.sensor_model}",

--- a/examples/beluga/beluga_benchmark.py
+++ b/examples/beluga/beluga_benchmark.py
@@ -24,6 +24,7 @@ import lambkin
 )
 @lambkin.option("--clock-rate", default=100.0)
 @lambkin.option("--sensor-topic", default="/scan")
+@lambkin.option("--dry-run", default=False)
 def nominal(ctx):
     """Run a nominal Beluga AMCL benchmark across sensor models and particle counts.
 
@@ -39,6 +40,7 @@ def nominal(ctx):
     print(f"sensor_topic: {ctx.options.sensor_topic}")
     print(f"source: {ctx.source}")
     print("---")
+    ctx.shell = lambkin.ShellProxy(dry_run=ctx.options.dry_run)
     ctx.shell.ros2.launch(
         ctx.source.path.parent / "beluga.launch.xml",
         f"sensor_model:={ctx.variant.sensor_model}",

--- a/src/lambkin/__init__.py
+++ b/src/lambkin/__init__.py
@@ -16,9 +16,11 @@
 
 from lambkin.common import named_product
 from lambkin.core.decorators import benchmark, option
+from lambkin.core.shell.proxy import ShellProxy
 
 __all__ = [
     "benchmark",
     "named_product",
     "option",
+    "ShellProxy",
 ]

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -23,6 +23,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+from lambkin.core.shell import ShellProxy
+
 from .source import Source
 
 
@@ -176,7 +178,7 @@ class Context:
         # as parameters.
 
         # ctx.shell
-        # TODO(teresa-ortega): self.shell = Shell(self)
+        self.shell = ShellProxy()
 
     def _setup_directories(self) -> None:
         """Create variant and iteration directories."""

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -178,7 +178,7 @@ class Context:
         # as parameters.
 
         # ctx.shell
-        self.shell = ShellProxy()
+        self.shell = ShellProxy(dry_run=getattr(self.options, "dry_run", False))
 
     def _setup_directories(self) -> None:
         """Create variant and iteration directories."""

--- a/src/lambkin/core/shell/__init__.py
+++ b/src/lambkin/core/shell/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shell subpackage for the lambkin SDK.
+
+Provides shell abstractions for executing system commands within benchmarks.
+Each shell implementation exposes the same interface, allowing benchmarks to
+switch between dry-run and real execution without changing any benchmark code.
+"""
+
+from .proxy import ShellProxy
+
+__all__ = [
+    "ShellProxy",
+]

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -27,13 +27,14 @@ from typing import Any
 class _CommandProxy:
     """Builds a shell command lazily by chaining attribute access and calls."""
 
-    def __init__(self, parts: list[str]) -> None:
+    def __init__(self, parts: list[str], dry_run: bool = False) -> None:
         """Initialize the proxy with the command words accumulated so far."""
         self._parts = parts
+        self._dry_run = dry_run
 
     def __getattr__(self, name: str) -> _CommandProxy:
         """Append a new word to the command and return a new proxy."""
-        return _CommandProxy(self._parts + [name])
+        return _CommandProxy(self._parts + [name], self._dry_run)
 
     def __call__(self, *args: Any, **kwargs: Any) -> None:
         """Finalize and print the command.
@@ -59,12 +60,19 @@ class _CommandProxy:
                 extra.extend([flag, shlex.quote(str(value))])
 
         command = " ".join(self._parts + extra)
-        print(f"[CMD]: {command}")
+
+        if self._dry_run:
+            # TODO: extend to dispatch commands to BackgroundProcess for real execution.
+            print(f"[CMD]: {command}")
 
 
 class ShellProxy:
     """Dry-run mock shell that prints commands instead of executing them."""
 
+    def __init__(self, dry_run: bool = False) -> None:
+        """Initialize the ShellProxy with the given dry_run flag."""
+        self._dry_run = dry_run
+
     def __getattr__(self, name: str) -> _CommandProxy:
         """Start building a new command from the given top-level tool name."""
-        return _CommandProxy([name])
+        return _CommandProxy([name], self._dry_run)

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -17,3 +17,50 @@
 Provides an abstraction over shell command dispatch, allowing benchmark
 processes to be launched and managed through a consistent interface.
 """
+
+from __future__ import annotations
+
+import shlex
+from typing import Any
+
+
+class _CommandProxy:
+    """Builds a shell command lazily by chaining attribute access and calls."""
+
+    def __init__(self, parts: list[str]) -> None:
+        """Initialize the proxy with the command words accumulated so far."""
+        self._parts = parts
+
+    def __getattr__(self, name: str) -> _CommandProxy:
+        """Append a new word to the command and return a new proxy."""
+        return _CommandProxy(self._parts + [name])
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        """Finalize and print the command.
+
+        Positional args are appended as plain tokens. Keyword args are
+        converted to --flag value pairs, with underscores replaced by hyphens.
+        Boolean True values produce a standalone flag, False values are ignored.
+        """
+        extra = []
+
+        for arg in args:
+            extra.append(str(arg))
+
+        for key, value in kwargs.items():
+            flag = "--" + key.replace("_", "-")
+            if value is True:
+                extra.append(flag)
+            elif value is not False:
+                extra.extend([flag, shlex.quote(str(value))])
+
+        command = " ".join(self._parts + extra)
+        print(f"[CMD]: {command}")
+
+
+class ShellProxy:
+    """Dry-run mock shell that prints commands instead of executing them."""
+
+    def __getattr__(self, name: str) -> _CommandProxy:
+        """Start building a new command from the given top-level tool name."""
+        return _CommandProxy([name])

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -38,9 +38,13 @@ class _CommandProxy:
     def __call__(self, *args: Any, **kwargs: Any) -> None:
         """Finalize and print the command.
 
-        Positional args are appended as plain tokens. Keyword args are
-        converted to --flag value pairs, with underscores replaced by hyphens.
-        Boolean True values produce a standalone flag, False values are ignored.
+        Positional args are appended as quoted tokens to handle paths with
+        spaces correctly. Keyword args are converted to --flag value pairs,
+        with underscores replaced by hyphens. Boolean True values produce a
+        standalone flag, False values are ignored.
+
+        This is a dry-run implementation that will be extended to dispatch
+        commands to BackgroundProcess for real execution.
         """
         extra = []
 

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -45,7 +45,7 @@ class _CommandProxy:
         extra = []
 
         for arg in args:
-            extra.append(str(arg))
+            extra.append(shlex.quote(str(arg)))
 
         for key, value in kwargs.items():
             flag = "--" + key.replace("_", "-")

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -64,6 +64,10 @@ class _CommandProxy:
         if self._dry_run:
             # TODO: extend to dispatch commands to BackgroundProcess for real execution.
             print(f"[CMD]: {command}")
+        else:
+            raise NotImplementedError(
+                "Real execution is not yet supported, use dry_run=True."
+            )
 
 
 class ShellProxy:

--- a/test/core/test_shell.py
+++ b/test/core/test_shell.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the shell class in lambkin.core.shell."""
+
+import pytest
+
+from lambkin.core.shell import ShellProxy
+
+
+@pytest.fixture
+def shell():
+    """Return a fresh ShellProxy instance for each test."""
+    return ShellProxy()
+
+
+def test_simple_command(shell, capsys):
+    """Test that a simple single-level command is printed correctly."""
+    shell.ros2.launch("beluga.launch.xml")
+    assert capsys.readouterr().out == "[CMD]: ros2 launch beluga.launch.xml\n"
+
+
+def test_chained_command(shell, capsys):
+    """Test that chained attribute access builds the command word by word."""
+    shell.ros2.bag.play("my_bag")
+    assert capsys.readouterr().out == "[CMD]: ros2 bag play my_bag\n"
+
+
+def test_multiple_args(shell, capsys):
+    """Test that multiple positional arguments are appended in order."""
+    shell.ros2.bag.play("my_bag", "--clock", "-r", "1.0")
+    assert capsys.readouterr().out == "[CMD]: ros2 bag play my_bag --clock -r 1.0\n"
+
+
+def test_kwarg_becomes_flag(shell, capsys):
+    """Test that keyword arguments are converted to --flag value pairs."""
+    shell.evo_ape.bag2("output.mcap", save_results="out.zip")
+    assert (
+        capsys.readouterr().out
+        == "[CMD]: evo_ape bag2 output.mcap --save-results out.zip\n"
+    )
+
+
+def test_arbitrary_tool(shell, capsys):
+    """Test that any top-level tool name works without hardcoding."""
+    shell.evo.traj("output.mcap")
+    assert capsys.readouterr().out == "[CMD]: evo traj output.mcap\n"

--- a/test/core/test_shell.py
+++ b/test/core/test_shell.py
@@ -22,7 +22,7 @@ from lambkin.core.shell import ShellProxy
 @pytest.fixture
 def shell():
     """Return a fresh ShellProxy instance for each test."""
-    return ShellProxy()
+    return ShellProxy(dry_run=True)
 
 
 def test_simple_command(shell, capsys):

--- a/test/core/test_shell.py
+++ b/test/core/test_shell.py
@@ -56,3 +56,30 @@ def test_arbitrary_tool(shell, capsys):
     """Test that any top-level tool name works without hardcoding."""
     shell.evo.traj("output.mcap")
     assert capsys.readouterr().out == "[CMD]: evo traj output.mcap\n"
+
+
+def test_kwarg_true_is_standalone_flag(shell, capsys):
+    """Test that a boolean True kwarg produces a standalone flag."""
+    shell.ros2.bag.play("my_bag", clock=True)
+    assert capsys.readouterr().out == "[CMD]: ros2 bag play my_bag --clock\n"
+
+
+def test_kwarg_false_is_ignored(shell, capsys):
+    """Test that a boolean False kwarg is ignored."""
+    shell.ros2.bag.play("my_bag", clock=False)
+    assert capsys.readouterr().out == "[CMD]: ros2 bag play my_bag\n"
+
+
+def test_path_with_spaces(shell, capsys):
+    """Test that positional args with spaces are correctly quoted."""
+    shell.ros2.bag.play("/my path/to/bag.mcap")
+    assert capsys.readouterr().out == "[CMD]: ros2 bag play '/my path/to/bag.mcap'\n"
+
+
+def test_kwarg_multiple_underscores_converted(shell, capsys):
+    """Test that multiple underscores in kwarg names are converted to dashes."""
+    shell.evo_ape.bag2("output.mcap", save_all_results="out.zip")
+    assert (
+        capsys.readouterr().out
+        == "[CMD]: evo_ape bag2 output.mcap --save-all-results out.zip\n"
+    )


### PR DESCRIPTION
### Proposed changes

A ShellProxy class under the shell/ subpackage as a first step towards a full shell abstraction layer. Commands like 
```python
ctx.shell.ros2.launch(...)
ctx.shell.evo_ape.bag2(...)
print [CMD]: <full command> 
```
to stdout instead of executing anything. The interface is fully generic, making it easily extensible and keeping benchmark code unchanged when swapping in a real shell implementation later.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥  No breaking changes.

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments
N/A