### PR TITLE
Phase 3: Simplify example logging using __repr__

### DIFF
--- a/examples/beluga/beluga_benchmark.py
+++ b/examples/beluga/beluga_benchmark.py
@@ -34,12 +34,7 @@ def nominal(ctx):
     Args:
         ctx: Lambkin context with variant, options, source, and shell access.
     """
-    print(f"variation: {ctx.variant.sensor_model}, {ctx.variant.num_particles}")
-    print(f"iteration: {ctx.iteration}")
-    print(f"clock_rate: {ctx.options.clock_rate}")
-    print(f"sensor_topic: {ctx.options.sensor_topic}")
-    print(f"source: {ctx.source}")
-    print("---")
+    print(ctx)
     ctx.shell.ros2.launch(
         ctx.source.path.parent / "beluga.launch.xml",
         f"sensor_model:={ctx.variant.sensor_model}",
@@ -47,6 +42,18 @@ def nominal(ctx):
     )
     ctx.shell.ros2.bag.play("--clock", "-r", ctx.options.clock_rate)
     ctx.shell.evo_ape.bag2("output.mcap", save_results="out.zip")
+
+
+@nominal.input
+def dataset(ctx):
+    """Return the path to the MCAP dataset used as input for the benchmark."""
+    return "/mydataset/dataset.mcap"
+
+
+@nominal.input
+def map(ctx):
+    """Return the path to the map file used for localization."""
+    return "my_map.yaml"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Proposed changes

Replace multiple individual print statements with a single `print(ctx)`, using the existing `Context.__repr__` method to produce a structured, human-readable summary of the context state.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes.

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Additional comments

N/A
