### PR TITLE
Phase 3: verify error message in option tests

### DIFF
--- a/test/core/test_option.py
+++ b/test/core/test_option.py
@@ -76,7 +76,10 @@ def test_option_stacks_bottom_up():
 
 def test_option_fails_on_invalid_declaration(simple_fn):
     """option() raises an error if the flag name is invalid."""
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match=r"Invalid flag name: 'clock-rate'\. Must start with '-' or '--'\.",
+    ):
         option("clock-rate")(simple_fn)
 
 


### PR DESCRIPTION
### Proposed changes

Add a message validation to the test to verify the error message raised by the `@option` decorator when an invalid flag is declared, not just the exception type.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes. 

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments

N/A
