### PR TITLE
Phase 4: create metadata files

### DIFF
--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -19,10 +19,11 @@ configuration, runtime metadata, and cleanup hooks. Shared across the process
 layer and decorators during a run.
 """
 
+import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-import datetime
+
 import yaml
 
 from lambkin.core.shell import ShellProxy

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -22,6 +22,8 @@ layer and decorators during a run.
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+import datetime
+import yaml
 
 from lambkin.core.shell import ShellProxy
 
@@ -165,6 +167,7 @@ class Context:
             if output_dir
             else source.path.parent / Context.BENCHMARKS_DIRNAME
         )
+        self._variant_index = variant_index
         variant_dir = base / _variant_folder_name(variant_index)
         iteration_dir = variant_dir / _iteration_folder_name(iteration)
         self.output = OutputInfo(
@@ -179,6 +182,32 @@ class Context:
 
         # ctx.shell
         self.shell = ShellProxy(dry_run=getattr(self.options, "dry_run", False))
+        self._started_at = datetime.datetime.now().isoformat()
+        self._write_metadata()
+
+    def _write_metadata(self) -> None:
+        """Write a YAML metadata file to the iteration output directory.
+
+        Serializes run identity, parameters, source, and output paths
+        to 'metadata.yaml inside 'output.iteration_dir'. The file
+        is written once at context creation time and is not updated afterwards.
+        """
+        metadata = {
+            "started_at": self._started_at,
+            "variant_index": self._variant_index,
+            "iteration": self.iteration,
+            "variant": vars(self.variant),
+            "options": vars(self.options),
+            "source": str(self.source.path),
+            "output": {
+                "base_dir": str(self.output.base_dir),
+                "variant_dir": str(self.output.variant_dir),
+                "iteration_dir": str(self.output.iteration_dir),
+            },
+        }
+        meta_path = self.output.iteration_dir / "metadata.yaml"
+        with open(meta_path, "w") as f:
+            yaml.dump(metadata, f, default_flow_style=False, sort_keys=False)
 
     def _setup_directories(self) -> None:
         """Create variant and iteration directories."""

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -84,6 +84,12 @@ def benchmark(variants, num_iterations):
             cli_args = sys.argv[1:] if args is None else args
             options = _parse_options(fn, cli_args)
             source = Source(path=inspect.getfile(fn))
+            # The base context creates a directory for variant 1 / iteration 1
+            # containing a metadata file with the information available at this
+            # point in time.
+            # This directory will later be overwritten with the
+            # actual data collected for variant 1 / iteration 1 during
+            # execution.
             base_ctx = Context(
                 variant={},
                 iteration=0,
@@ -92,6 +98,8 @@ def benchmark(variants, num_iterations):
                 variant_index=0,
                 output_dir=output_dir,
             )
+            # TODO(teresa-ortega): Consider an alternative approach for managing
+            # the base context.
             inputs.resolve(base_ctx)
             resolved_inputs = base_ctx.inputs
             for variant_index, variant in enumerate(variants):


### PR DESCRIPTION
### Proposed changes

Add YAML metadata file generation to each benchmark iteration output folder.
At context creation, _write_metadata() writes metadata.yaml with run identity, variant parameters, options, source path, output paths, and start timestamp.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Additional comments

N/A
