### PR TITLE
Phase 4: Make Context immutable

### DIFF
--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -81,26 +81,29 @@ def _iteration_folder_name(iteration: int) -> str:
 class Context:
     """Carries all namespaced information for one benchmark variant.
 
-    Builds all namespaced sub-objects (variant, inputs, options, output)
-    from the given parameters and automatically creates the required output
-    folders on disk.
+    Immutable by design: all fields are set once at construction time
+    and cannot be reassigned afterwards. Any attempt to set or delete
+    an attribute after construction raises an AttributeError.
 
     Attributes:
     ----------
-    BENCHMARKS_DIRNAME : str
-        Name for the benchmarks directory.
-    variation:
+    variant : SimpleNamespace
         Namespaced algorithm parameters for this run.
         All key-value pairs from the variant dict are exposed as attributes.
-    source:
-        Source object describing the benchmark script being executed.
-    inputs:
-        Namespaced input information.
-    options:
+    options : SimpleNamespace
         Namespaced runtime options.
         All key-value pairs from the options dict are exposed as attributes.
-    output:
-        Namespaced output paths.
+    inputs : SimpleNamespace
+        Namespaced input information, injected by the benchmark runner
+        after resolving all registered input hooks.
+    iteration : int
+        Zero-based repetition index within this variant.
+    source : Source
+        Source object describing the benchmark script being executed.
+    output : OutputInfo
+        Namespaced output paths for this variant and iteration.
+    shell : ShellProxy
+        Shell proxy for running commands during the benchmark.
     """
 
     BENCHMARKS_DIRNAME = "results"
@@ -111,6 +114,7 @@ class Context:
         iteration: int,
         options: dict[str, Any],
         source: Source,
+        inputs: SimpleNamespace | None = None,
         variant_index: int = 0,
         output_dir: Path | str | None = None,
     ) -> None:
@@ -153,16 +157,16 @@ class Context:
         object.__setattr__(self, "source", source)
 
         # ctx.inputs
-        object.__setattr__(self, "inputs", SimpleNamespace())
+        object.__setattr__(self, "inputs", inputs)
 
         # ctx.iteration
         object.__setattr__(self, "iteration", iteration)
 
-        # TODO: Consider moving path construction logic into OutputInfo itself,
-        # giving it a constructor that takes base_dir, variation_index, and
-        # iteration and derives variation_dir and iteration_dir internally. This
-        # would make OutputInfo a cohesive object that owns everything
-        # path-related.
+        # TODO(teresa-ortega): Consider moving path construction logic into
+        # OutputInfo itself, giving it a constructor that takes base_dir,
+        # variation_index, and iteration and derives variation_dir and
+        # iteration_dir internally. This would make OutputInfo a cohesive object
+        # that owns everything path-related
 
         # ctx.output
         base = (
@@ -170,7 +174,6 @@ class Context:
             if output_dir
             else source.path.parent / Context.BENCHMARKS_DIRNAME
         )
-        self._variant_index = variant_index
         variant_dir = base / _variant_folder_name(variant_index)
         iteration_dir = variant_dir / _iteration_folder_name(iteration)
         object.__setattr__(

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -159,6 +159,9 @@ class Context:
         # ctx.iteration
         object.__setattr__(self, "iteration", iteration)
 
+        # ctx._variant_index
+        object.__setattr__(self, "_variant_index", variant_index)
+
         # TODO(teresa-ortega): Consider moving path construction logic into
         # OutputInfo itself, giving it a constructor that takes base_dir,
         # variation_index, and iteration and derives variation_dir and
@@ -191,7 +194,7 @@ class Context:
         object.__setattr__(
             self, "shell", ShellProxy(dry_run=getattr(self.options, "dry_run", False))
         )
-        self._started_at = datetime.datetime.now().isoformat()
+        object.__setattr__(self, "_started_at", datetime.datetime.now().isoformat())
         self._write_metadata()
 
     def _write_metadata(self) -> None:

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -81,29 +81,26 @@ def _iteration_folder_name(iteration: int) -> str:
 class Context:
     """Carries all namespaced information for one benchmark variant.
 
-    Immutable by design: all fields are set once at construction time
-    and cannot be reassigned afterwards. Any attempt to set or delete
-    an attribute after construction raises an AttributeError.
+    Builds all namespaced sub-objects (variant, inputs, options, output)
+    from the given parameters and automatically creates the required output
+    folders on disk.
 
     Attributes:
     ----------
-    variant : SimpleNamespace
+    BENCHMARKS_DIRNAME : str
+        Name for the benchmarks directory.
+    variation:
         Namespaced algorithm parameters for this run.
         All key-value pairs from the variant dict are exposed as attributes.
-    options : SimpleNamespace
+    source:
+        Source object describing the benchmark script being executed.
+    inputs:
+        Namespaced input information.
+    options:
         Namespaced runtime options.
         All key-value pairs from the options dict are exposed as attributes.
-    inputs : SimpleNamespace
-        Namespaced input information, injected by the benchmark runner
-        after resolving all registered input hooks.
-    iteration : int
-        Zero-based repetition index within this variant.
-    source : Source
-        Source object describing the benchmark script being executed.
-    output : OutputInfo
-        Namespaced output paths for this variant and iteration.
-    shell : ShellProxy
-        Shell proxy for running commands during the benchmark.
+    output:
+        Namespaced output paths.
     """
 
     BENCHMARKS_DIRNAME = "results"

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -20,6 +20,7 @@ layer and decorators during a run.
 """
 
 import datetime
+from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -76,6 +77,7 @@ def _iteration_folder_name(iteration: int) -> str:
     return f"iter_{iteration + 1}"
 
 
+@dataclass(frozen=True)
 class Context:
     """Carries all namespaced information for one benchmark variant.
 
@@ -142,19 +144,19 @@ class Context:
             defaults to "source.path.parent".
         """
         # ctx.variant
-        self.variant = SimpleNamespace(**variant)
+        object.__setattr__(self, "variant", SimpleNamespace(**variant))
 
         # ctx.options
-        self.options = SimpleNamespace(**options)
+        object.__setattr__(self, "options", SimpleNamespace(**options))
 
         # ctx.source
-        self.source = source
+        object.__setattr__(self, "source", source)
 
         # ctx.inputs
-        self.inputs = SimpleNamespace()
+        object.__setattr__(self, "inputs", SimpleNamespace())
 
         # ctx.iteration
-        self.iteration = iteration
+        object.__setattr__(self, "iteration", iteration)
 
         # TODO: Consider moving path construction logic into OutputInfo itself,
         # giving it a constructor that takes base_dir, variation_index, and
@@ -171,10 +173,14 @@ class Context:
         self._variant_index = variant_index
         variant_dir = base / _variant_folder_name(variant_index)
         iteration_dir = variant_dir / _iteration_folder_name(iteration)
-        self.output = OutputInfo(
-            base_dir=base,
-            variant_dir=variant_dir,
-            iteration_dir=iteration_dir,
+        object.__setattr__(
+            self,
+            "output",
+            OutputInfo(
+                base_dir=base,
+                variant_dir=variant_dir,
+                iteration_dir=iteration_dir,
+            ),
         )
 
         self._setup_directories()
@@ -182,7 +188,9 @@ class Context:
         # as parameters.
 
         # ctx.shell
-        self.shell = ShellProxy(dry_run=getattr(self.options, "dry_run", False))
+        object.__setattr__(
+            self, "shell", ShellProxy(dry_run=getattr(self.options, "dry_run", False))
+        )
         self._started_at = datetime.datetime.now().isoformat()
         self._write_metadata()
 

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -100,8 +100,7 @@ def benchmark(variants, num_iterations):
             )
             # TODO(teresa-ortega): Consider an alternative approach for managing
             # the base context.
-            inputs.resolve(base_ctx)
-            resolved_inputs = base_ctx.inputs
+            resolved_inputs = inputs.resolve(base_ctx)
             for variant_index, variant in enumerate(variants):
                 for iteration in range(num_iterations):
                     ctx = Context(
@@ -109,10 +108,10 @@ def benchmark(variants, num_iterations):
                         iteration=iteration,
                         options=options,
                         source=source,
+                        inputs=resolved_inputs,
                         variant_index=variant_index,
                         output_dir=output_dir,
                     )
-                    object.__setattr__(ctx, "inputs", resolved_inputs)
                     fn(ctx)
 
         wrapper.input = inputs.register

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -112,7 +112,7 @@ def benchmark(variants, num_iterations):
                         variant_index=variant_index,
                         output_dir=output_dir,
                     )
-                    ctx.inputs = resolved_inputs
+                    object.__setattr__(ctx, "inputs", resolved_inputs)
                     fn(ctx)
 
         wrapper.input = inputs.register

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -85,6 +85,5 @@ class InputRegistry:
         for hook in self._hooks:
             result = hook(ctx)
             _validate_result(hook, result)
-            resolved[hook.__name__] = result  # dict local, ctx no se toca
-
+            resolved[hook.__name__] = result
         return SimpleNamespace(**resolved)

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -21,6 +21,7 @@ injecting their return values into "ctx.inputs" under the hook's function name.
 """
 
 import inspect
+from types import SimpleNamespace
 
 
 def _validate_result(hook_fn, result) -> None:
@@ -74,8 +75,16 @@ class InputRegistry:
         return hook_fn
 
     def resolve(self, ctx):
-        """Resolve all registered input hooks."""
+        """Resolve all registered input hooks and return a SimpleNamespace snapshot.
+
+        Collects all hook results into a local dict first so ctx is never
+        mutated during resolution. The returned snapshot is passed to the
+        Context constructor by the benchmark runner.
+        """
+        resolved = {}
         for hook in self._hooks:
             result = hook(ctx)
             _validate_result(hook, result)
-            setattr(ctx.inputs, hook.__name__, result)
+            resolved[hook.__name__] = result  # dict local, ctx no se toca
+
+        return SimpleNamespace(**resolved)

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -14,9 +14,7 @@
 
 """Unit tests for the benchmark decorator in lambkin.core.decorators."""
 
-from dataclasses import FrozenInstanceError
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -179,31 +177,3 @@ def test_benchmark_empty_variants_raises_error(tmp_path):
         @benchmark(variants=[], num_iterations=1)
         def fn(ctx):
             pass
-
-
-def test_context_is_immutable(tmp_path):
-    """Context fields cannot be reassigned after construction."""
-    source = Source("/my_benchmark.py")
-    ctx = Context(
-        variant={"sensor_model": "beam"},
-        iteration=0,
-        options={"dry_run": True},
-        source=source,
-        variant_index=0,
-        output_dir=tmp_path,
-    )
-
-    with pytest.raises(FrozenInstanceError):
-        ctx.variant = SimpleNamespace()
-
-    with pytest.raises(FrozenInstanceError):
-        ctx.options = SimpleNamespace()
-
-    with pytest.raises(FrozenInstanceError):
-        ctx.inputs = SimpleNamespace()
-
-    with pytest.raises(FrozenInstanceError):
-        ctx.iteration = 99
-
-    with pytest.raises(FrozenInstanceError):
-        ctx.shell = None

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -14,7 +14,9 @@
 
 """Unit tests for the benchmark decorator in lambkin.core.decorators."""
 
+from dataclasses import FrozenInstanceError
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -177,3 +179,31 @@ def test_benchmark_empty_variants_raises_error(tmp_path):
         @benchmark(variants=[], num_iterations=1)
         def fn(ctx):
             pass
+
+
+def test_context_is_immutable(tmp_path):
+    """Context fields cannot be reassigned after construction."""
+    source = Source("/my_benchmark.py")
+    ctx = Context(
+        variant={"sensor_model": "beam"},
+        iteration=0,
+        options={"dry_run": True},
+        source=source,
+        variant_index=0,
+        output_dir=tmp_path,
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        ctx.variant = SimpleNamespace()
+
+    with pytest.raises(FrozenInstanceError):
+        ctx.options = SimpleNamespace()
+
+    with pytest.raises(FrozenInstanceError):
+        ctx.inputs = SimpleNamespace()
+
+    with pytest.raises(FrozenInstanceError):
+        ctx.iteration = 99
+
+    with pytest.raises(FrozenInstanceError):
+        ctx.shell = None

--- a/test/core/test_context.py
+++ b/test/core/test_context.py
@@ -228,3 +228,31 @@ def test_context_default_output_dir(tmp_path):
         source=source,
     )
     assert ctx.output.base_dir == tmp_path / Context.BENCHMARKS_DIRNAME
+
+
+def test_context_is_immutable(tmp_path):
+    """Context fields cannot be reassigned after construction."""
+    source = Source("/my_benchmark.py")
+    ctx = Context(
+        variant={"sensor_model": "beam"},
+        iteration=0,
+        options={"dry_run": True},
+        source=source,
+        variant_index=0,
+        output_dir=tmp_path,
+    )
+
+    with pytest.raises(AttributeError):
+        ctx.variant = SimpleNamespace()
+
+    with pytest.raises(AttributeError):
+        ctx.options = SimpleNamespace()
+
+    with pytest.raises(AttributeError):
+        ctx.inputs = SimpleNamespace()
+
+    with pytest.raises(AttributeError):
+        ctx.iteration = 99
+
+    with pytest.raises(AttributeError):
+        ctx.shell = None

--- a/test/core/test_context.py
+++ b/test/core/test_context.py
@@ -178,24 +178,8 @@ def test_source_path_is_set_correctly(ctx):
 
 
 def test_inputs_defaults_to_empty_namespace(ctx):
-    """ctx.inputs is an empty SimpleNamespace when no inputs are registered."""
-    assert isinstance(ctx.inputs, SimpleNamespace)
-    assert vars(ctx.inputs) == {}
-
-
-def test_inputs_can_be_dynamically_populated(ctx):
-    """ctx.inputs correctly accepts dynamic attribute assignments via setattr().
-
-    This verifies the behavior required by the @nominal.input system.
-    """
-    test_dataset = "/data/bags/run1.bag"
-    test_folder = "/data/my_folder"
-
-    ctx.inputs.dataset = test_dataset
-    ctx.inputs.my_folder = test_folder
-
-    assert ctx.inputs.dataset == test_dataset
-    assert ctx.inputs.my_folder == test_folder
+    """ctx.inputs is None when no inputs are registered."""
+    assert ctx.inputs is None
 
 
 @pytest.mark.parametrize("iteration", [0, 1, 5, 42])

--- a/test/core/test_input.py
+++ b/test/core/test_input.py
@@ -17,6 +17,7 @@
 import pytest
 
 from lambkin.core.ctx import Context
+from lambkin.core.ctx.source import Source
 from lambkin.core.decorators.benchmark import benchmark
 from lambkin.core.decorators.input import InputRegistry
 
@@ -72,10 +73,16 @@ def test_hook_with_extra_parameters_raises():
         registry.register(bad_hook)
 
 
-def test_hook_returning_none_raises():
+def test_hook_returning_none_raises(tmp_path):
     """A hook that returns None raises ValueError."""
     registry = InputRegistry()
-    ctx = Context.__new__(Context)
+    ctx = Context(
+        variant={},
+        iteration=0,
+        options={},
+        source=Source("/my_benchmark.py"),
+        output_dir=tmp_path,
+    )
 
     def dataset(ctx):
         return None
@@ -85,10 +92,16 @@ def test_hook_returning_none_raises():
         registry.resolve(ctx)
 
 
-def test_hook_with_no_return_raises():
+def test_hook_with_no_return_raises(tmp_path):
     """A hook with no return statement raises ValueError."""
     registry = InputRegistry()
-    ctx = Context.__new__(Context)
+    ctx = Context(
+        variant={},
+        iteration=0,
+        options={},
+        source=Source("/my_benchmark.py"),
+        output_dir=tmp_path,
+    )
 
     def dataset(ctx):
         pass
@@ -98,10 +111,16 @@ def test_hook_with_no_return_raises():
         registry.resolve(ctx)
 
 
-def test_hook_returning_empty_string_raises():
+def test_hook_returning_empty_string_raises(tmp_path):
     """A hook that returns an empty string raises ValueError."""
     registry = InputRegistry()
-    ctx = Context.__new__(Context)
+    ctx = Context(
+        variant={},
+        iteration=0,
+        options={},
+        source=Source("/my_benchmark.py"),
+        output_dir=tmp_path,
+    )
 
     def dataset(ctx):
         return ""
@@ -111,10 +130,16 @@ def test_hook_returning_empty_string_raises():
         registry.resolve(ctx)
 
 
-def test_hook_returning_blank_string_raises():
+def test_hook_returning_blank_string_raises(tmp_path):
     """A hook that returns a whitespace-only string raises ValueError."""
     registry = InputRegistry()
-    ctx = Context.__new__(Context)
+    ctx = Context(
+        variant={},
+        iteration=0,
+        options={},
+        source=Source("/my_benchmark.py"),
+        output_dir=tmp_path,
+    )
 
     def dataset(ctx):
         return "   "

--- a/test/core/test_input.py
+++ b/test/core/test_input.py
@@ -42,12 +42,14 @@ def test_register_returns_original_function():
 def test_registered_hook_name_is_preserved():
     """The ctx.inputs attribute name is the hook's __name__."""
     registry = InputRegistry()
+    ctx = Context.__new__(Context)
 
     def my_dataset(ctx):
-        return "x"
+        return "some_value"
 
     registry.register(my_dataset)
-    assert registry._hooks[0].__name__ == "my_dataset"
+    result = registry.resolve(ctx)
+    assert hasattr(result, "my_dataset")
 
 
 def test_hook_with_no_parameters_raises():

--- a/test/core/test_input.py
+++ b/test/core/test_input.py
@@ -17,7 +17,6 @@
 import pytest
 
 from lambkin.core.ctx import Context
-from lambkin.core.ctx.source import Source
 from lambkin.core.decorators.benchmark import benchmark
 from lambkin.core.decorators.input import InputRegistry
 
@@ -73,16 +72,10 @@ def test_hook_with_extra_parameters_raises():
         registry.register(bad_hook)
 
 
-def test_hook_returning_none_raises(tmp_path):
+def test_hook_returning_none_raises():
     """A hook that returns None raises ValueError."""
     registry = InputRegistry()
-    ctx = Context(
-        variant={},
-        iteration=0,
-        options={},
-        source=Source("/my_benchmark.py"),
-        output_dir=tmp_path,
-    )
+    ctx = Context.__new__(Context)
 
     def dataset(ctx):
         return None
@@ -92,16 +85,10 @@ def test_hook_returning_none_raises(tmp_path):
         registry.resolve(ctx)
 
 
-def test_hook_with_no_return_raises(tmp_path):
+def test_hook_with_no_return_raises():
     """A hook with no return statement raises ValueError."""
     registry = InputRegistry()
-    ctx = Context(
-        variant={},
-        iteration=0,
-        options={},
-        source=Source("/my_benchmark.py"),
-        output_dir=tmp_path,
-    )
+    ctx = Context.__new__(Context)
 
     def dataset(ctx):
         pass
@@ -111,16 +98,10 @@ def test_hook_with_no_return_raises(tmp_path):
         registry.resolve(ctx)
 
 
-def test_hook_returning_empty_string_raises(tmp_path):
+def test_hook_returning_empty_string_raises():
     """A hook that returns an empty string raises ValueError."""
     registry = InputRegistry()
-    ctx = Context(
-        variant={},
-        iteration=0,
-        options={},
-        source=Source("/my_benchmark.py"),
-        output_dir=tmp_path,
-    )
+    ctx = Context.__new__(Context)
 
     def dataset(ctx):
         return ""
@@ -130,16 +111,10 @@ def test_hook_returning_empty_string_raises(tmp_path):
         registry.resolve(ctx)
 
 
-def test_hook_returning_blank_string_raises(tmp_path):
+def test_hook_returning_blank_string_raises():
     """A hook that returns a whitespace-only string raises ValueError."""
     registry = InputRegistry()
-    ctx = Context(
-        variant={},
-        iteration=0,
-        options={},
-        source=Source("/my_benchmark.py"),
-        output_dir=tmp_path,
-    )
+    ctx = Context.__new__(Context)
 
     def dataset(ctx):
         return "   "


### PR DESCRIPTION
### Proposed changes

Previously, any part of the code could mutate ctx freely, making the execution flow hard to reason about. This PR decorates Context with @dataclass(frozen=True) so any field reassignment raises a FrozenInstanceError. Since the dataclass blocks writes in __init__ too, internal assignments use object.__setattr__, which is the standard Python pattern for frozen dataclasses with custom construction logic. A new test test_context_is_immutable verifies the behaviour.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments
N/A
