### PR TITLE
Phase 4: Real Command Execution

### DIFF
--- a/src/lambkin/common/__init__.py
+++ b/src/lambkin/common/__init__.py
@@ -14,13 +14,14 @@
 
 """Common utilities and primitives shared across the lambkin SDK.
 
-Exposes named_product and all base exceptions for convenience.
+Provides defaults, named products, and base exceptions.
 """
 
-from .defaults import DRY_RUN_DEFAULT
+from lambkin.common import defaults
+
 from .named_product import named_product
 
 __all__ = [
+    "defaults",
     "named_product",
-    "DRY_RUN_DEFAULT",
 ]

--- a/src/lambkin/common/defaults.py
+++ b/src/lambkin/common/defaults.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Default values for lambkin SDK options."""
+"""Default values shared across the lambkin SDK."""
 
-DRY_RUN_DEFAULT: bool = False
+DRY_RUN: bool = False

--- a/src/lambkin/common/defaults.py
+++ b/src/lambkin/common/defaults.py
@@ -12,15 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Common utilities and primitives shared across the lambkin SDK.
+"""Default values for lambkin SDK options."""
 
-Exposes named_product and all base exceptions for convenience.
-"""
-
-from .defaults import DRY_RUN_DEFAULT
-from .named_product import named_product
-
-__all__ = [
-    "named_product",
-    "DRY_RUN_DEFAULT",
-]
+DRY_RUN_DEFAULT: bool = False

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -27,7 +27,7 @@ from typing import Any
 
 import yaml
 
-from lambkin.common.defaults import DRY_RUN_DEFAULT
+from lambkin.common import defaults
 from lambkin.core.shell import ShellProxy
 
 from .source import Source
@@ -194,7 +194,7 @@ class Context:
             self,
             "shell",
             ShellProxy(
-                dry_run=getattr(self.options, "dry_run", DRY_RUN_DEFAULT),
+                dry_run=getattr(self.options, "dry_run", defaults.DRY_RUN),
                 cwd=iteration_dir,
             ),
         )

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -176,6 +176,7 @@ class Context:
         )
         variant_dir = base / _variant_folder_name(variant_index)
         iteration_dir = variant_dir / _iteration_folder_name(iteration)
+        object.__setattr__(self, "iteration_dir", iteration_dir)
         object.__setattr__(
             self,
             "output",
@@ -192,7 +193,12 @@ class Context:
 
         # ctx.shell
         object.__setattr__(
-            self, "shell", ShellProxy(dry_run=getattr(self.options, "dry_run", False))
+            self,
+            "shell",
+            ShellProxy(
+                dry_run=getattr(self.options, "dry_run", False),
+                cwd=self.iteration_dir,
+            ),
         )
         object.__setattr__(self, "_started_at", datetime.datetime.now().isoformat())
         self._write_metadata()

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -27,6 +27,7 @@ from typing import Any
 
 import yaml
 
+from lambkin.common.defaults import DRY_RUN_DEFAULT
 from lambkin.core.shell import ShellProxy
 
 from .source import Source
@@ -193,7 +194,7 @@ class Context:
             self,
             "shell",
             ShellProxy(
-                dry_run=getattr(self.options, "dry_run", False),
+                dry_run=getattr(self.options, "dry_run", DRY_RUN_DEFAULT),
                 cwd=iteration_dir,
             ),
         )

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -194,7 +194,7 @@ class Context:
             "shell",
             ShellProxy(
                 dry_run=getattr(self.options, "dry_run", False),
-                cwd=variant_dir / _iteration_folder_name(iteration),
+                cwd=iteration_dir,
             ),
         )
         object.__setattr__(self, "_started_at", datetime.datetime.now().isoformat())

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -176,7 +176,6 @@ class Context:
         )
         variant_dir = base / _variant_folder_name(variant_index)
         iteration_dir = variant_dir / _iteration_folder_name(iteration)
-        object.__setattr__(self, "iteration_dir", iteration_dir)
         object.__setattr__(
             self,
             "output",
@@ -188,8 +187,6 @@ class Context:
         )
 
         self._setup_directories()
-        # TODO(teresa-ortega): Implement a metadata file to remap folder names
-        # as parameters.
 
         # ctx.shell
         object.__setattr__(
@@ -197,7 +194,7 @@ class Context:
             "shell",
             ShellProxy(
                 dry_run=getattr(self.options, "dry_run", False),
-                cwd=self.iteration_dir,
+                cwd=variant_dir / _iteration_folder_name(iteration),
             ),
         )
         object.__setattr__(self, "_started_at", datetime.datetime.now().isoformat())

--- a/src/lambkin/core/shell/__init__.py
+++ b/src/lambkin/core/shell/__init__.py
@@ -19,8 +19,9 @@ Each shell implementation exposes the same interface, allowing benchmarks to
 switch between dry-run and real execution without changing any benchmark code.
 """
 
-from .proxy import ShellProxy
+from .proxy import CommandError, ShellProxy
 
 __all__ = [
     "ShellProxy",
+    "CommandError",
 ]

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -26,25 +26,30 @@ from typing import Any
 
 
 class CommandError(Exception):
-    """Raised when a shell command exits with a non-zero return code.
+    """Raised when a shell command cannot be started or exits with an error.
 
-    Wraps subprocess.CalledProcessError to decouple the rest of the codebase
-    from the subprocess module and to carry the argv list and return code in a
-    single, inspectable object.
+    Attributes:
+        command:    The argv list passed to the operating system.
+        returncode: Exit code of the process, or None if it never started.
     """
 
-    def __init__(self, command: list[str], returncode: int) -> None:
-        """Initialize the error with the command that failed and its return code.
+    def __init__(
+        self,
+        command: list[str],
+        message: str,
+        returncode: int | None = None,
+    ) -> None:
+        """Initialize the error with the command that failed and its cause.
 
         Args:
-            command: The argv list that was passed to the operating system.
-            returncode: The non-zero exit code returned by the process.
+            command:    The argv list that was passed to the operating system.
+            message:    Human-readable description of the failure.
+            returncode: The exit code returned by the process, or None if it
+                        never started.
         """
         self.command = command
         self.returncode = returncode
-        super().__init__(
-            f"Command {shlex.join(command)!r} failed with return code {returncode}"
-        )
+        super().__init__(message)
 
 
 class _CommandProxy:
@@ -138,7 +143,28 @@ class _CommandProxy:
         try:
             return subprocess.run(argv, check=True)
         except subprocess.CalledProcessError as e:
-            raise CommandError(argv, e.returncode) from e
+            raise CommandError(
+                argv,
+                f"Command {shlex.join(argv)!r} failed with return code {e.returncode}.",
+                returncode=e.returncode,
+            ) from e
+        except FileNotFoundError:
+            raise CommandError(
+                argv,
+                f"Command not found: {argv[0]!r}. "
+                f"Make sure it is installed and available on PATH.",
+            ) from None
+        except PermissionError:
+            raise CommandError(
+                argv,
+                f"Permission denied: {argv[0]!r} is not executable."
+                f"Check file permissions.",
+            ) from None
+        except OSError as e:
+            raise CommandError(
+                argv,
+                f"OS error while starting {argv[0]!r}: {e}.",
+            ) from e
 
 
 class ShellProxy:

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -147,6 +147,11 @@ class _CommandProxy:
             print(f"[DRY RUN] {shlex.join(argv)}")
             return None
         try:
+            # TODO(teresa-ortega): subprocess.run inherits stdout/stderr from
+            # the parent process, so all output goes directly to the terminal
+            # with no way to capture, redirect, or log it. When logging is
+            # revisited, consider switching to subprocess.Popen for full control
+            # over stdout/stderr streams.
             return subprocess.run(argv, check=True, cwd=self._cwd)
         except subprocess.CalledProcessError as e:
             raise CommandError(

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -136,8 +136,8 @@ class _CommandProxy:
             **kwargs: Keyword arguments converted to --flag value pairs.
 
         Returns:
-            The CompletedProcess instance returned by subprocess.run, or None
-            in dry-run mode.
+            The CompletedProcess instance returned by subprocess.run,or a
+            dummy CompletedProcess(argv, returncode=0) in dry-run mode.
 
         Raises:
             CommandError: If the process exits with a non-zero return code.
@@ -145,7 +145,7 @@ class _CommandProxy:
         argv = self._build_argv(*args, **kwargs)
         if self._dry_run:
             print(f"[DRY RUN] {shlex.join(argv)}")
-            return None
+            return subprocess.CompletedProcess(argv, returncode=0)
         try:
             # TODO(teresa-ortega): subprocess.run inherits stdout/stderr from
             # the parent process, so all output goes directly to the terminal

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -123,7 +123,7 @@ class _CommandProxy:
                 extra.extend([flag, str(value)])
         return self._parts + extra
 
-    def __call__(self, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess | None:
+    def __call__(self, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
         """Finalise the command and dispatch it to the operating system.
 
         In dry-run mode, prints the command and returns None. In real mode,
@@ -136,7 +136,7 @@ class _CommandProxy:
             **kwargs: Keyword arguments converted to --flag value pairs.
 
         Returns:
-            The CompletedProcess instance returned by subprocess.run,or a
+            The CompletedProcess instance returned by subprocess.run, or a
             dummy CompletedProcess(argv, returncode=0) in dry-run mode.
 
         Raises:

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -154,6 +154,8 @@ class _CommandProxy:
                 f"Command {shlex.join(argv)!r} failed with return code {e.returncode}.",
                 returncode=e.returncode,
             ) from e
+        # FileNotFoundError and PermissionError must come before OSError,
+        # as they are subclasses of it. Order matters here.
         except FileNotFoundError:
             raise CommandError(
                 argv,

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import shlex
 import subprocess
+from pathlib import Path
 from typing import Any
 
 
@@ -64,15 +65,20 @@ class _CommandProxy:
     obtain the first proxy in a chain.
     """
 
-    def __init__(self, parts: list[str], dry_run: bool = False) -> None:
+    def __init__(
+        self, parts: list[str], dry_run: bool = False, cwd: Path | None = None
+    ) -> None:
         """Initialize the proxy with the command tokens accumulated so far.
 
         Args:
             parts: The list of command tokens accumulated so far.
             dry_run: If True, commands are printed instead of executed.
+            cwd: Working directory for the command when dispatched. Inherited
+            from ShellProxy and propagated through every chained proxy.
         """
         self._parts = parts
         self._dry_run = dry_run
+        self._cwd = cwd
 
     def __getattr__(self, name: str) -> _CommandProxy:
         """Append a new token to the command and return a new proxy.
@@ -86,7 +92,7 @@ class _CommandProxy:
         Returns:
             A new proxy with the token appended.
         """
-        return _CommandProxy(self._parts + [name], self._dry_run)
+        return _CommandProxy(self._parts + [name], self._dry_run, self._cwd)
 
     def _build_argv(self, *args: Any, **kwargs: Any) -> list[str]:
         """Build the final argv list from positional and keyword arguments.
@@ -141,7 +147,7 @@ class _CommandProxy:
             print(f"[DRY RUN] {shlex.join(argv)}")
             return None
         try:
-            return subprocess.run(argv, check=True)
+            return subprocess.run(argv, check=True, cwd=self._cwd)
         except subprocess.CalledProcessError as e:
             raise CommandError(
                 argv,
@@ -157,7 +163,7 @@ class _CommandProxy:
         except PermissionError:
             raise CommandError(
                 argv,
-                f"Permission denied: {argv[0]!r} is not executable."
+                f"Permission denied: {argv[0]!r} is not executable. "
                 f"Check file permissions.",
             ) from None
         except OSError as e:
@@ -183,13 +189,16 @@ class ShellProxy:
     for testing and for recording what a benchmark would do without running it.
     """
 
-    def __init__(self, dry_run: bool = False) -> None:
+    def __init__(self, dry_run: bool = False, cwd: Path | None = None) -> None:
         """Initialize the ShellProxy.
 
         Args:
             dry_run: If True, commands are printed instead of executed.
+            cwd: Working directory for all commands dispatched through this proxy.
+            If None, the current working directory of the process is used.
         """
         self._dry_run = dry_run
+        self._cwd = cwd
 
     def __getattr__(self, name: str) -> _CommandProxy:
         """Start building a new command from the given top-level token.
@@ -200,4 +209,4 @@ class ShellProxy:
         Returns:
             A CommandProxy with the first token set.
         """
-        return _CommandProxy([name], self._dry_run)
+        return _CommandProxy([name], self._dry_run, self._cwd)

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -21,62 +21,157 @@ processes to be launched and managed through a consistent interface.
 from __future__ import annotations
 
 import shlex
+import subprocess
 from typing import Any
 
 
+class CommandError(Exception):
+    """Raised when a shell command exits with a non-zero return code.
+
+    Wraps subprocess.CalledProcessError to decouple the rest of the codebase
+    from the subprocess module and to carry the argv list and return code in a
+    single, inspectable object.
+    """
+
+    def __init__(self, command: list[str], returncode: int) -> None:
+        """Initialize the error with the command that failed and its return code.
+
+        Args:
+            command: The argv list that was passed to the operating system.
+            returncode: The non-zero exit code returned by the process.
+        """
+        self.command = command
+        self.returncode = returncode
+        super().__init__(
+            f"Command {shlex.join(command)!r} failed with return code {returncode}"
+        )
+
+
 class _CommandProxy:
-    """Builds a shell command lazily by chaining attribute access and calls."""
+    """Builds a shell command lazily by chaining attribute access and calls.
+
+    Each attribute access appends a new token to the command being constructed
+    and returns a new proxy. Calling the proxy finalises the command and
+    dispatches it to the operating system via subprocess, or prints it in
+    dry-run mode.
+
+    This class is not meant to be instantiated directly. Use ShellProxy to
+    obtain the first proxy in a chain.
+    """
 
     def __init__(self, parts: list[str], dry_run: bool = False) -> None:
-        """Initialize the proxy with the command words accumulated so far."""
+        """Initialize the proxy with the command tokens accumulated so far.
+
+        Args:
+            parts: The list of command tokens accumulated so far.
+            dry_run: If True, commands are printed instead of executed.
+        """
         self._parts = parts
         self._dry_run = dry_run
 
     def __getattr__(self, name: str) -> _CommandProxy:
-        """Append a new word to the command and return a new proxy."""
+        """Append a new token to the command and return a new proxy.
+
+        This allows chaining attribute access to build multi-word commands.
+        For example, shell.ros2.topic.list() builds ['ros2', 'topic', 'list'].
+
+        Args:
+            name: The token to append to the command.
+
+        Returns:
+            A new proxy with the token appended.
+        """
         return _CommandProxy(self._parts + [name], self._dry_run)
 
-    def __call__(self, *args: Any, **kwargs: Any) -> None:
-        """Finalize and print the command.
+    def _build_argv(self, *args: Any, **kwargs: Any) -> list[str]:
+        """Build the final argv list from positional and keyword arguments.
 
-        Positional args are appended as quoted tokens to handle paths with
-        spaces correctly. Keyword args are converted to --flag value pairs,
-        with underscores replaced by hyphens. Boolean True values produce a
-        standalone flag, False values are ignored.
+        Positional arguments are appended as discrete tokens. Keyword arguments
+        are converted to --flag value pairs, with underscores replaced by
+        hyphens. A boolean True value produces a standalone flag. A boolean
+        False value is omitted entirely.
 
-        This is a dry-run implementation that will be extended to dispatch
-        commands to BackgroundProcess for real execution.
+        This method is shared by __call__ and will be shared by background()
+        when that is implemented, so that argv construction is never duplicated.
+
+        Args:
+            *args: Positional arguments to append as tokens.
+            **kwargs: Keyword arguments to convert to --flag value pairs.
+
+        Returns:
+            The complete argv list ready to pass to the operating system.
         """
-        extra = []
-
+        extra: list[str] = []
         for arg in args:
-            extra.append(shlex.quote(str(arg)))
-
+            extra.append(str(arg))
         for key, value in kwargs.items():
             flag = "--" + key.replace("_", "-")
             if value is True:
                 extra.append(flag)
             elif value is not False:
-                extra.extend([flag, shlex.quote(str(value))])
+                extra.extend([flag, str(value)])
+        return self._parts + extra
 
-        command = " ".join(self._parts + extra)
+    def __call__(self, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess | None:
+        """Finalise the command and dispatch it to the operating system.
 
+        In dry-run mode, prints the command and returns None. In real mode,
+        runs the command as a foreground process, blocking until it completes.
+        The process inherits stdout and stderr from the parent, so its output
+        goes directly to the terminal.
+
+        Args:
+            *args: Positional arguments appended as tokens to the command.
+            **kwargs: Keyword arguments converted to --flag value pairs.
+
+        Returns:
+            The CompletedProcess instance returned by subprocess.run, or None
+            in dry-run mode.
+
+        Raises:
+            CommandError: If the process exits with a non-zero return code.
+        """
+        argv = self._build_argv(*args, **kwargs)
         if self._dry_run:
-            # TODO: extend to dispatch commands to BackgroundProcess for real execution.
-            print(f"[CMD]: {command}")
-        else:
-            raise NotImplementedError(
-                "Real execution is not yet supported, use dry_run=True."
-            )
+            print(f"[DRY RUN] {shlex.join(argv)}")
+            return None
+        try:
+            return subprocess.run(argv, check=True)
+        except subprocess.CalledProcessError as e:
+            raise CommandError(argv, e.returncode) from e
 
 
 class ShellProxy:
-    """Dry-run mock shell that prints commands instead of executing them."""
+    """Shell proxy that dispatches commands to the operating system.
+
+    Attribute access on this object starts building a command. Each subsequent
+    attribute access appends a token. Calling the result dispatches the command.
+
+    Example:
+        shell = ShellProxy()
+        shell.ros2.topic.list()          # runs: ros2 topic list
+        shell.echo("hello", "world")     # runs: echo hello world
+        shell.my_tool(verbose=True)      # runs: my_tool --verbose
+
+    In dry-run mode, commands are printed instead of executed, which is useful
+    for testing and for recording what a benchmark would do without running it.
+    """
 
     def __init__(self, dry_run: bool = False) -> None:
-        """Initialize the ShellProxy with the given dry_run flag."""
+        """Initialize the ShellProxy.
+
+        Args:
+            dry_run: If True, commands are printed instead of executed.
+        """
         self._dry_run = dry_run
 
     def __getattr__(self, name: str) -> _CommandProxy:
-        """Start building a new command from the given top-level tool name."""
+        """Start building a new command from the given top-level token.
+
+        Args:
+            name: The first token of the command, typically the program name.
+
+        Returns:
+            A CommandProxy with the first token set.
+        """
         return _CommandProxy([name], self._dry_run)

--- a/test/core/test_shell.py
+++ b/test/core/test_shell.py
@@ -112,6 +112,7 @@ def test_not_found_raises_command_error(shell):
         shell.this_command_does_not_exist_at_all()
     assert exc_info.value.returncode is None
     assert "not found" in str(exc_info.value).lower()
+    assert "this_command_does_not_exist_at_all" in str(exc_info.value)
 
 
 def test_permission_error_raises_command_error(shell, tmp_path):
@@ -125,46 +126,12 @@ def test_permission_error_raises_command_error(shell, tmp_path):
     assert "permission" in str(exc_info.value).lower()
 
 
-def test_command_error_message_contains_command(shell):
-    """CommandError message contains the command that failed."""
-    with pytest.raises(CommandError) as exc_info:
-        shell.false()
-    assert "false" in str(exc_info.value)
-
-
-def test_not_found_message_contains_command_name(shell):
-    """CommandError message for not found contains the command name."""
-    with pytest.raises(CommandError) as exc_info:
-        shell.this_command_does_not_exist_at_all()
-    assert "this_command_does_not_exist_at_all" in str(exc_info.value)
-
-
-def test_command_error_carries_returncode(shell):
+def test_command_error_carries_returncode_and_argv(shell):
     """CommandError carries the non-zero return code of the failed command."""
     with pytest.raises(CommandError) as exc_info:
         shell.false()
     assert exc_info.value.returncode == 1
-
-
-def test_command_error_carries_argv(shell):
-    """CommandError carries the argv list of the failed command."""
-    with pytest.raises(CommandError) as exc_info:
-        shell.false()
     assert exc_info.value.command == ["false"]
-
-
-def test_path_with_spaces_no_shell_injection(shell, tmp_path):
-    """A path with spaces is passed as a single token, not split by a shell."""
-    target = tmp_path / "my file.txt"
-    shell.touch(str(target))
-    assert target.exists()
-
-
-def test_kwarg_value_with_spaces_no_injection(shell, tmp_path):
-    """A kwarg value with spaces is passed as a single token."""
-    target = tmp_path / "out file.txt"
-    shell.touch(str(target))
-    assert target.exists()
 
 
 def test_dry_run_returns_none(dry_shell):
@@ -181,3 +148,10 @@ def test_chained_proxy_independence(dry_shell, capsys):
     out = capsys.readouterr().out
     assert "[DRY RUN] ros2 bag play bag1" in out
     assert "[DRY RUN] ros2 bag record bag2" in out
+
+
+def test_path_with_spaces_no_shell_injection(shell, tmp_path):
+    """A path with spaces is passed as a single token, not split by the shell."""
+    target = tmp_path / "my file.txt"
+    shell.touch(str(target))
+    assert target.exists()

--- a/test/core/test_shell.py
+++ b/test/core/test_shell.py
@@ -96,7 +96,6 @@ def test_arbitrary_tool(dry_shell, capsys):
 def test_successful_command(shell):
     """A successful command returns a CompletedProcess with returncode 0."""
     result = shell.echo("hello")
-    assert result is not None
     assert result.returncode == 0
 
 

--- a/test/core/test_shell.py
+++ b/test/core/test_shell.py
@@ -14,72 +14,157 @@
 
 """Unit tests for the shell class in lambkin.core.shell."""
 
+import subprocess
+
 import pytest
 
-from lambkin.core.shell import ShellProxy
+from lambkin.core.shell import CommandError, ShellProxy
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
 
 
 @pytest.fixture
 def shell():
-    """Return a fresh ShellProxy instance for each test."""
+    """Return a ShellProxy in real execution mode."""
+    return ShellProxy(dry_run=False)
+
+
+@pytest.fixture
+def dry_shell():
+    """Return a ShellProxy in dry-run mode."""
     return ShellProxy(dry_run=True)
 
 
-def test_simple_command(shell, capsys):
-    """Test that a simple single-level command is printed correctly."""
-    shell.ros2.launch("beluga.launch.xml")
-    assert capsys.readouterr().out == "[CMD]: ros2 launch beluga.launch.xml\n"
+# ── dry-run: command construction ─────────────────────────────────────────────
 
 
-def test_chained_command(shell, capsys):
-    """Test that chained attribute access builds the command word by word."""
-    shell.ros2.bag.play("my_bag")
-    assert capsys.readouterr().out == "[CMD]: ros2 bag play my_bag\n"
+def test_simple_command(dry_shell, capsys):
+    """A single-level command is printed correctly."""
+    dry_shell.echo("hello")
+    assert capsys.readouterr().out == "[DRY RUN] echo hello\n"
 
 
-def test_multiple_args(shell, capsys):
-    """Test that multiple positional arguments are appended in order."""
-    shell.ros2.bag.play("my_bag", "--clock", "-r", "1.0")
-    assert capsys.readouterr().out == "[CMD]: ros2 bag play my_bag --clock -r 1.0\n"
+def test_chained_command(dry_shell, capsys):
+    """Chained attribute access builds the command word by word."""
+    dry_shell.ros2.bag.play("my_bag")
+    assert capsys.readouterr().out == "[DRY RUN] ros2 bag play my_bag\n"
 
 
-def test_kwarg_becomes_flag(shell, capsys):
-    """Test that keyword arguments are converted to --flag value pairs."""
-    shell.evo_ape.bag2("output.mcap", save_results="out.zip")
+def test_multiple_positional_args(dry_shell, capsys):
+    """Multiple positional arguments are appended in order."""
+    dry_shell.ros2.bag.play("my_bag", "--clock", "-r", "1.0")
+    assert capsys.readouterr().out == "[DRY RUN] ros2 bag play my_bag --clock -r 1.0\n"
+
+
+def test_kwarg_becomes_flag(dry_shell, capsys):
+    """Keyword arguments are converted to --flag value pairs."""
+    dry_shell.evo_ape.bag2("output.mcap", save_results="out.zip")
     assert (
         capsys.readouterr().out
-        == "[CMD]: evo_ape bag2 output.mcap --save-results out.zip\n"
+        == "[DRY RUN] evo_ape bag2 output.mcap --save-results out.zip\n"
     )
 
 
-def test_arbitrary_tool(shell, capsys):
-    """Test that any top-level tool name works without hardcoding."""
-    shell.evo.traj("output.mcap")
-    assert capsys.readouterr().out == "[CMD]: evo traj output.mcap\n"
+def test_kwarg_true_is_standalone_flag(dry_shell, capsys):
+    """A boolean True kwarg produces a standalone flag."""
+    dry_shell.ros2.bag.play("my_bag", clock=True)
+    assert capsys.readouterr().out == "[DRY RUN] ros2 bag play my_bag --clock\n"
 
 
-def test_kwarg_true_is_standalone_flag(shell, capsys):
-    """Test that a boolean True kwarg produces a standalone flag."""
-    shell.ros2.bag.play("my_bag", clock=True)
-    assert capsys.readouterr().out == "[CMD]: ros2 bag play my_bag --clock\n"
+def test_kwarg_false_is_omitted(dry_shell, capsys):
+    """A boolean False kwarg is omitted entirely."""
+    dry_shell.ros2.bag.play("my_bag", clock=False)
+    assert capsys.readouterr().out == "[DRY RUN] ros2 bag play my_bag\n"
 
 
-def test_kwarg_false_is_ignored(shell, capsys):
-    """Test that a boolean False kwarg is ignored."""
-    shell.ros2.bag.play("my_bag", clock=False)
-    assert capsys.readouterr().out == "[CMD]: ros2 bag play my_bag\n"
-
-
-def test_path_with_spaces(shell, capsys):
-    """Test that positional args with spaces are correctly quoted."""
-    shell.ros2.bag.play("/my path/to/bag.mcap")
-    assert capsys.readouterr().out == "[CMD]: ros2 bag play '/my path/to/bag.mcap'\n"
-
-
-def test_kwarg_multiple_underscores_converted(shell, capsys):
-    """Test that multiple underscores in kwarg names are converted to dashes."""
-    shell.evo_ape.bag2("output.mcap", save_all_results="out.zip")
+def test_kwarg_multiple_underscores_converted(dry_shell, capsys):
+    """Multiple underscores in kwarg names are all converted to dashes."""
+    dry_shell.evo_ape.bag2("output.mcap", save_all_results="out.zip")
     assert (
         capsys.readouterr().out
-        == "[CMD]: evo_ape bag2 output.mcap --save-all-results out.zip\n"
+        == "[DRY RUN] evo_ape bag2 output.mcap --save-all-results out.zip\n"
     )
+
+
+def test_path_with_spaces(dry_shell, capsys):
+    """Positional args with spaces are quoted correctly."""
+    dry_shell.ros2.bag.play("/my path/to/bag.mcap")
+    assert capsys.readouterr().out == "[DRY RUN] ros2 bag play '/my path/to/bag.mcap'\n"
+
+
+def test_arbitrary_tool(dry_shell, capsys):
+    """Any top-level tool name works without hardcoding."""
+    dry_shell.evo.traj("output.mcap")
+    assert capsys.readouterr().out == "[DRY RUN] evo traj output.mcap\n"
+
+
+# ── real execution ────────────────────────────────────────────────────────────
+
+
+def test_successful_command(shell):
+    """A successful command returns a CompletedProcess with returncode 0."""
+    result = shell.echo("hello")
+    assert result is not None
+    assert result.returncode == 0
+
+
+def test_returns_completed_process(shell):
+    """__call__ returns a CompletedProcess instance on success."""
+    result = shell.true()
+    assert isinstance(result, subprocess.CompletedProcess)
+
+
+def test_failed_command_raises_command_error(shell):
+    """A command that exits with non-zero raises CommandError."""
+    with pytest.raises(CommandError):
+        shell.false()
+
+
+def test_command_error_carries_returncode(shell):
+    """CommandError carries the non-zero return code of the failed command."""
+    with pytest.raises(CommandError) as exc_info:
+        shell.false()
+    assert exc_info.value.returncode == 1
+
+
+def test_command_error_carries_argv(shell):
+    """CommandError carries the argv list of the failed command."""
+    with pytest.raises(CommandError) as exc_info:
+        shell.false()
+    assert exc_info.value.command == ["false"]
+
+
+def test_path_with_spaces_no_shell_injection(shell, tmp_path):
+    """A path with spaces is passed as a single token, not split by a shell."""
+    target = tmp_path / "my file.txt"
+    shell.touch(str(target))
+    assert target.exists()
+
+
+def test_kwarg_value_with_spaces_no_injection(shell, tmp_path):
+    """A kwarg value with spaces is passed as a single token."""
+    target = tmp_path / "out file.txt"
+    shell.touch(str(target))
+    assert target.exists()
+
+
+def test_unknown_command_raises_file_not_found(shell):
+    """An unknown command raises FileNotFoundError, not CommandError."""
+    with pytest.raises(FileNotFoundError):
+        shell.this_command_does_not_exist_at_all()
+
+
+def test_dry_run_returns_none(dry_shell):
+    """In dry-run mode, __call__ returns None instead of CompletedProcess."""
+    result = dry_shell.echo("hello")
+    assert result is None
+
+
+def test_chained_proxy_independence(dry_shell, capsys):
+    """Each chained proxy is independent — reusing a base proxy works correctly."""
+    base = dry_shell.ros2.bag
+    base.play("bag1")
+    base.record("bag2")
+    out = capsys.readouterr().out
+    assert "[DRY RUN] ros2 bag play bag1" in out
+    assert "[DRY RUN] ros2 bag record bag2" in out

--- a/test/core/test_shell.py
+++ b/test/core/test_shell.py
@@ -106,7 +106,7 @@ def test_returns_completed_process(shell):
     assert isinstance(result, subprocess.CompletedProcess)
 
 
-def test_not_found_raises_command_error(shell):
+def test_not_found_raises_command_error_and_contains_command_name(shell):
     """A command that does not exist raises CommandError with a helpful message."""
     with pytest.raises(CommandError) as exc_info:
         shell.this_command_does_not_exist_at_all()

--- a/test/core/test_shell.py
+++ b/test/core/test_shell.py
@@ -20,8 +20,6 @@ import pytest
 
 from lambkin.core.shell import CommandError, ShellProxy
 
-# ── fixtures ──────────────────────────────────────────────────────────────────
-
 
 @pytest.fixture
 def shell():
@@ -33,9 +31,6 @@ def shell():
 def dry_shell():
     """Return a ShellProxy in dry-run mode."""
     return ShellProxy(dry_run=True)
-
-
-# ── dry-run: command construction ─────────────────────────────────────────────
 
 
 def test_simple_command(dry_shell, capsys):
@@ -98,9 +93,6 @@ def test_arbitrary_tool(dry_shell, capsys):
     assert capsys.readouterr().out == "[DRY RUN] evo traj output.mcap\n"
 
 
-# ── real execution ────────────────────────────────────────────────────────────
-
-
 def test_successful_command(shell):
     """A successful command returns a CompletedProcess with returncode 0."""
     result = shell.echo("hello")
@@ -114,10 +106,37 @@ def test_returns_completed_process(shell):
     assert isinstance(result, subprocess.CompletedProcess)
 
 
-def test_failed_command_raises_command_error(shell):
-    """A command that exits with non-zero raises CommandError."""
-    with pytest.raises(CommandError):
+def test_not_found_raises_command_error(shell):
+    """A command that does not exist raises CommandError with a helpful message."""
+    with pytest.raises(CommandError) as exc_info:
+        shell.this_command_does_not_exist_at_all()
+    assert exc_info.value.returncode is None
+    assert "not found" in str(exc_info.value).lower()
+
+
+def test_permission_error_raises_command_error(shell, tmp_path):
+    """A non-executable file raises CommandError with a helpful message."""
+    script = tmp_path / "script.sh"
+    script.write_text("#!/bin/bash\necho hello\n")
+    script.chmod(0o644)
+    with pytest.raises(CommandError) as exc_info:
+        shell.__getattr__(str(script))()
+    assert exc_info.value.returncode is None
+    assert "permission" in str(exc_info.value).lower()
+
+
+def test_command_error_message_contains_command(shell):
+    """CommandError message contains the command that failed."""
+    with pytest.raises(CommandError) as exc_info:
         shell.false()
+    assert "false" in str(exc_info.value)
+
+
+def test_not_found_message_contains_command_name(shell):
+    """CommandError message for not found contains the command name."""
+    with pytest.raises(CommandError) as exc_info:
+        shell.this_command_does_not_exist_at_all()
+    assert "this_command_does_not_exist_at_all" in str(exc_info.value)
 
 
 def test_command_error_carries_returncode(shell):
@@ -146,12 +165,6 @@ def test_kwarg_value_with_spaces_no_injection(shell, tmp_path):
     target = tmp_path / "out file.txt"
     shell.touch(str(target))
     assert target.exists()
-
-
-def test_unknown_command_raises_file_not_found(shell):
-    """An unknown command raises FileNotFoundError, not CommandError."""
-    with pytest.raises(FileNotFoundError):
-        shell.this_command_does_not_exist_at_all()
 
 
 def test_dry_run_returns_none(dry_shell):

--- a/test/core/test_shell.py
+++ b/test/core/test_shell.py
@@ -134,10 +134,12 @@ def test_command_error_carries_returncode_and_argv(shell):
     assert exc_info.value.command == ["false"]
 
 
-def test_dry_run_returns_none(dry_shell):
-    """In dry-run mode, __call__ returns None instead of CompletedProcess."""
+def test_dry_run_returns_completed_process(dry_shell):
+    """In dry-run mode, __call__ returns a dummy CompletedProcess with returncode=0."""
     result = dry_shell.echo("hello")
-    assert result is None
+    assert isinstance(result, subprocess.CompletedProcess)
+    assert result.returncode == 0
+    assert result.args == ["echo", "hello"]
 
 
 def test_chained_proxy_independence(dry_shell, capsys):


### PR DESCRIPTION
### Proposed changes

Implements real command execution via subprocess.run, extending the existing dry-run mode. Commands are dispatched as list[str], bypassing shell interpretation entirely. CommandError is extended to cover all failure modes — command not found, permission denied, and generic OS errors — each with a descriptive message.

#### How to Test
The following manual tests exercise the shell execution layer against real ROS 2 commands. Each test requires a sourced ROS 2 environment:
```bash
source /opt/ros/jazzy/setup.bash
source /ws/install/setup.bash
```
##### Test 1 — Launch. 
Verifies that ros2 launch runs correctly as a foreground process. Uncomment the launch lines in the benchmark file and run:
```python
ctx.shell.ros2.launch(
    ctx.source.path.parent / "beluga.launch.xml",
    f"sensor_model:={ctx.variant.sensor_model}",
    f"num_particles:={ctx.variant.num_particles}",
)
```
```bash
python3 examples/beluga/beluga_benchmark.py
```
##### Test 2 — Dry run. 
Verifies that no command is executed and the expected argv is printed for each step. Uncomment @lambkin.option("--dry-run", default=True) and run:
```bash
python3 examples/beluga/beluga_benchmark.py
```
Expected output per iteration:

[DRY RUN] ros2 bag record --output my_record --topics /tf

##### Test 3 — Record. 
Verifies that ros2 bag record runs correctly and that the output lands in the correct iteration directory. Each iteration should produce its own folder under results/var_N/iter_N/my_record/:
```python
ctx.shell.ros2.bag.record(
    "--output", "my_record",
    "--topics", "/tf",
)
```

```bash
python3 examples/beluga/beluga_benchmark.py
```

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments

N/A


