### PR TITLE
Phase 4: Add CLI entry point and native SDK options

### DIFF
--- a/examples/beluga/beluga_benchmark.py
+++ b/examples/beluga/beluga_benchmark.py
@@ -24,7 +24,6 @@ import lambkin
 )
 @lambkin.option("--clock-rate", default=100.0)
 @lambkin.option("--sensor-topic", default="/scan")
-@lambkin.option("--dry-run", default=True)
 def nominal(ctx):
     """Run a nominal Beluga AMCL benchmark across sensor models and particle counts.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,6 @@ convention = "google"
 testpaths = ["test"]
 pythonpath = [".",
              "examples", "src"]
+
+[project.scripts]
+lambkin = "lambkin.cli:main"

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -28,8 +28,60 @@ import subprocess
 import sys
 from pathlib import Path
 
+import click
+from click.formatting import HelpFormatter
 
-def main() -> None:
+
+class LambkinCommand(click.Command):
+    """Custom Click command that renders SDK and custom options separately."""
+
+    def format_help(self, ctx: click.Context, formatter: HelpFormatter) -> None:
+        """Write the full help text with SDK and custom options sections."""
+        formatter.write_paragraph()
+        formatter.write_text(
+            "Usage: lambkin [OPTIONS] SCRIPT [SDK_OPTIONS] [CUSTOM_OPTIONS]"
+        )
+        formatter.write_paragraph()
+        formatter.write_text(
+            "LAMBKIN is a benchmarking SDK for robotics applications. "
+            "It runs your benchmark script inside a systemd cgroup scope, "
+            "ensuring all child processes are tracked and cleaned up automatically."
+        )
+        formatter.write_paragraph()
+
+        with formatter.section("Options"):
+            formatter.write_dl([("--help", "Show this message and exit.")])
+
+        with formatter.section("SDK Options (always available)"):
+            formatter.write_dl(
+                [
+                    (
+                        "--dry-run",
+                        "Run the benchmark in dry-run mode: "
+                        "commands are logged but not executed.",
+                    ),
+                    (
+                        "--show-options",
+                        "List all SDK and custom options available "
+                        "for this benchmark script and exit.",
+                    ),
+                ]
+            )
+
+        with formatter.section("Custom Options (script-defined)"):
+            formatter.write_text(
+                "Options registered in your benchmark script via @lambkin.option.\n"
+                "\nRun 'lambkin SCRIPT --show-options' to list them."
+            )
+
+
+@click.command(
+    cls=LambkinCommand,
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+@click.argument("script", type=click.Path(exists=True, path_type=Path))
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+def main(script: Path, args: tuple) -> None:
     """Launch a lambkin benchmark script inside a systemd cgroup scope.
 
     Re-executes ``script`` with the same Python interpreter, wrapped in
@@ -55,17 +107,6 @@ def main() -> None:
     # TODO(teresa-ortega): Handle concurrent runs, interrupted benchmarks, and re-runs
     # (e.g. detect an already active scope, support partial restarts).
     # To be addressed in phase 6.
-    if len(sys.argv) < 2:
-        print("Usage: lambkin <script.py> [args...]", file=sys.stderr)
-        sys.exit(1)
-
-    script = Path(sys.argv[1]).resolve()
-    if not script.exists():
-        print(f"Error: script not found: {script}", file=sys.stderr)
-        sys.exit(1)
-
-    args = sys.argv[2:]
-
     cgroup_scope = f"lambkin-{script.stem}.scope"
 
     try:
@@ -82,15 +123,13 @@ def main() -> None:
         )
     except KeyboardInterrupt:
         subprocess.run(
-            ["systemctl", "--user", "stop", cgroup_scope],
+            ["systemctl", "--user", "stop", "--wait", cgroup_scope],
             capture_output=True,
         )
         sys.exit(130)
-    except FileNotFoundError:
-        print(
-            "Error: 'systemd-run' not found. lambkin requires systemd.",
-            file=sys.stderr,
-        )
-        sys.exit(127)
+    except FileNotFoundError as err:
+        raise click.ClickException(
+            "'systemd-run' not found. lambkin requires systemd."
+        ) from err
 
     sys.exit(result.returncode)

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -63,16 +63,21 @@ def main() -> None:
     args = sys.argv[2:]
 
     cgroup_scope = f"lambkin-{script.stem}.scope"
-
-    result = subprocess.run(
-        [
-            "systemd-run",
-            "--scope",
-            f"--unit={cgroup_scope}",
-            "--user",
-            sys.executable,
-            str(script),
-            *args,
-        ],
-    )
+    try:
+        result = subprocess.run(
+            [
+                "systemd-run",
+                "--scope",
+                f"--unit={cgroup_scope}",
+                "--user",
+                sys.executable,
+                str(script),
+                *args,
+            ],
+        )
+    except FileNotFoundError:
+        print(
+            "Error: 'systemd-run' not found. lambkin requires systemd.", file=sys.stderr
+        )
+        sys.exit(127)
     sys.exit(result.returncode)

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -24,6 +24,7 @@ Typical usage::
     lambkin my_benchmark.py --clock-rate 50 --dry-run
 """
 
+import argparse
 import subprocess
 import sys
 from pathlib import Path
@@ -52,17 +53,42 @@ def main() -> None:
     SystemExit
         Always — propagates the child process return code.
     """
-    if len(sys.argv) < 2:
-        print("Usage: lambkin <script.py> [args...]", file=sys.stderr)
-        sys.exit(1)
+    parser = argparse.ArgumentParser(prog="lambkin")
+    parser.add_argument("script", type=str)
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Stop any existing run of the same benchmark and re-launch.",
+    )
+    args, forwarded = parser.parse_known_args()
 
-    script = Path(sys.argv[1]).resolve()
+    script = Path(args.script).resolve()
     if not script.exists():
         print(f"Error: script not found: {script}", file=sys.stderr)
         sys.exit(1)
     args = sys.argv[2:]
 
     cgroup_scope = f"lambkin-{script.stem}.scope"
+    check = subprocess.run(
+        ["systemctl", "--user", "is-active", cgroup_scope],
+        capture_output=True,
+    )
+    scope_active = check.returncode == 0
+
+    if scope_active and not args.overwrite:
+        print(
+            f"Error: scope '{cgroup_scope}' is already active. "
+            "Use --overwrite to stop it and re-launch.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if scope_active and args.overwrite:
+        subprocess.run(
+            ["systemctl", "--user", "stop", cgroup_scope],
+            capture_output=True,
+        )
+
     try:
         result = subprocess.run(
             [
@@ -72,12 +98,20 @@ def main() -> None:
                 "--user",
                 sys.executable,
                 str(script),
-                *args,
+                *forwarded,
             ],
         )
+    except KeyboardInterrupt:
+        subprocess.run(
+            ["systemctl", "--user", "stop", cgroup_scope],
+            capture_output=True,
+        )
+        sys.exit(130)  # convención: 128 + SIGINT
     except FileNotFoundError:
         print(
-            "Error: 'systemd-run' not found. lambkin requires systemd.", file=sys.stderr
+            "Error: 'systemd-run' not found. lambkin requires systemd.",
+            file=sys.stderr,
         )
         sys.exit(127)
+
     sys.exit(result.returncode)

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -66,7 +66,6 @@ def main() -> None:
     if not script.exists():
         print(f"Error: script not found: {script}", file=sys.stderr)
         sys.exit(1)
-    args = sys.argv[2:]
 
     cgroup_scope = f"lambkin-{script.stem}.scope"
     check = subprocess.run(

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -31,6 +31,10 @@ from pathlib import Path
 import click
 from click.formatting import HelpFormatter
 
+from lambkin.common.exceptions import (
+    LambkinSystemdNotFoundError,
+    LambkinSystemdScopeTimeoutError,
+)
 from lambkin.sdk_options import SDK_OPTIONS
 
 
@@ -78,12 +82,11 @@ def _stop_scope(cgroup_scope: str) -> None:
             capture_output=True,
             timeout=30,
         )
-    except subprocess.TimeoutExpired:
-        click.echo(
-            f"Warning: timed out waiting for scope '{cgroup_scope}' to stop. "
-            "Some processes may still be running.",
-            err=True,
-        )
+    except subprocess.TimeoutExpired as err:
+        raise LambkinSystemdScopeTimeoutError(
+            f"Timed out waiting for scope '{cgroup_scope}' to stop. "
+            "Some processes may still be running."
+        ) from err
 
 
 @click.command(
@@ -140,7 +143,7 @@ def main(script: Path, args: tuple) -> None:
         _stop_scope(cgroup_scope)
         sys.exit(130)
     except FileNotFoundError as err:
-        raise click.ClickException(
+        raise LambkinSystemdNotFoundError(
             "'systemd-run' not found. lambkin requires systemd."
         ) from err
 

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -56,7 +56,10 @@ def main() -> None:
         print("Usage: lambkin <script.py> [args...]", file=sys.stderr)
         sys.exit(1)
 
-    script = Path(sys.argv[1])
+    script = Path(sys.argv[1]).resolve()
+    if not script.exists():
+        print(f"Error: script not found: {script}", file=sys.stderr)
+        sys.exit(1)
     args = sys.argv[2:]
 
     cgroup_scope = f"lambkin-{script.stem}.scope"

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -86,12 +86,11 @@ def main(script: Path, args: tuple) -> None:
     unchanged, so SDK and user-defined CLI options (e.g. ``--dry-run``,
     ``--clock-rate``) are passed through transparently.
 
-    Exits with the same return code as the child process.
-
-    Raises:
-    ------
-    SystemExit
-        Always — propagates the child process return code.
+    Exit codes:
+        0    The benchmark script completed successfully.
+        1    An error occurred (e.g. systemd-run not found).
+        130  The benchmark was interrupted via Ctrl-C (SIGINT).
+        N    Any other return code is propagated from the benchmark script.
     """
     # TODO(teresa-ortega): Handle concurrent runs, interrupted benchmarks, and re-runs
     # (e.g. detect an already active scope, support partial restarts).

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -24,7 +24,6 @@ Typical usage::
     lambkin my_benchmark.py --clock-rate 50 --dry-run
 """
 
-import argparse
 import subprocess
 import sys
 from pathlib import Path
@@ -53,40 +52,21 @@ def main() -> None:
     SystemExit
         Always — propagates the child process return code.
     """
-    parser = argparse.ArgumentParser(prog="lambkin")
-    parser.add_argument("script", type=str)
-    parser.add_argument(
-        "--overwrite",
-        action="store_true",
-        help="Stop any existing run of the same benchmark and re-launch.",
-    )
-    args, forwarded = parser.parse_known_args()
+    # TODO(teresa-ortega): Handle concurrent runs, interrupted benchmarks, and re-runs
+    # (e.g. detect an already active scope, support partial restarts).
+    # To be addressed in phase 6.
+    if len(sys.argv) < 2:
+        print("Usage: lambkin <script.py> [args...]", file=sys.stderr)
+        sys.exit(1)
 
-    script = Path(args.script).resolve()
+    script = Path(sys.argv[1]).resolve()
     if not script.exists():
         print(f"Error: script not found: {script}", file=sys.stderr)
         sys.exit(1)
 
+    args = sys.argv[2:]
+
     cgroup_scope = f"lambkin-{script.stem}.scope"
-    check = subprocess.run(
-        ["systemctl", "--user", "is-active", cgroup_scope],
-        capture_output=True,
-    )
-    scope_active = check.returncode == 0
-
-    if scope_active and not args.overwrite:
-        print(
-            f"Error: scope '{cgroup_scope}' is already active. "
-            "Use --overwrite to stop it and re-launch.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    if scope_active and args.overwrite:
-        subprocess.run(
-            ["systemctl", "--user", "stop", cgroup_scope],
-            capture_output=True,
-        )
 
     try:
         result = subprocess.run(
@@ -97,7 +77,7 @@ def main() -> None:
                 "--user",
                 sys.executable,
                 str(script),
-                *forwarded,
+                *args,
             ],
         )
     except KeyboardInterrupt:
@@ -105,7 +85,7 @@ def main() -> None:
             ["systemctl", "--user", "stop", cgroup_scope],
             capture_output=True,
         )
-        sys.exit(130)  # convención: 128 + SIGINT
+        sys.exit(130)
     except FileNotFoundError:
         print(
             "Error: 'systemd-run' not found. lambkin requires systemd.",

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -96,7 +96,6 @@ def main(script: Path, args: tuple) -> None:
     # TODO(teresa-ortega): Handle concurrent runs, interrupted benchmarks, and re-runs
     # (e.g. detect an already active scope, support partial restarts).
     # To be addressed in phase 6.
-    script = script.resolve()
     cgroup_scope = f"lambkin-{script.stem}.scope"
 
     try:

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -31,6 +31,8 @@ from pathlib import Path
 import click
 from click.formatting import HelpFormatter
 
+from lambkin.sdk_options import SDK_OPTIONS
+
 
 class LambkinCommand(click.Command):
     """Custom Click command that renders SDK and custom options separately."""
@@ -53,26 +55,13 @@ class LambkinCommand(click.Command):
             formatter.write_dl([("--help", "Show this message and exit.")])
 
         with formatter.section("SDK Options (always available)"):
-            formatter.write_dl(
-                [
-                    (
-                        "--dry-run",
-                        "Run the benchmark in dry-run mode: "
-                        "commands are logged but not executed.",
-                    ),
-                    (
-                        "--show-options",
-                        "List all SDK and custom options available "
-                        "for this benchmark script and exit.",
-                    ),
-                ]
-            )
+            formatter.write_dl([(opt.opts[0], opt.help or "") for opt in SDK_OPTIONS])
 
         with formatter.section("Custom Options (script-defined)"):
             formatter.write_text(
-                "Options registered in your benchmark script via @lambkin.option.\n"
-                "\nRun 'lambkin SCRIPT --show-options' to list them."
+                "Options registered in your benchmark script via @lambkin.option."
             )
+            formatter.write_text("Run 'lambkin SCRIPT --show-options' to list them.")
 
 
 @click.command(

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -14,12 +14,11 @@
 
 """Entry point for the lambkin CLI.
 
-Exposes the ``lambkin`` command, registered as a console script in
-``pyproject.toml``. When invoked, it re-executes the given benchmark
-script under a transient systemd scope so that all child processes
-are placed in a dedicated cgroup v2 hierarchy automatically.
+When invoked, it re-executes the given benchmark script under a
+transient systemd scope so that all child processes are placed in a
+dedicated cgroup v2 hierarchy automatically.
 
-Typical usage::
+Typical usage:
 
     lambkin my_benchmark.py --clock-rate 50 --dry-run
 """

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -31,10 +31,7 @@ from pathlib import Path
 import click
 from click.formatting import HelpFormatter
 
-from lambkin.common.exceptions import (
-    LambkinSystemdNotFoundError,
-    LambkinSystemdScopeTimeoutError,
-)
+from lambkin.common import exceptions
 from lambkin.sdk_options import SDK_OPTIONS
 
 
@@ -83,7 +80,7 @@ def _stop_scope(cgroup_scope: str) -> None:
             timeout=30,
         )
     except subprocess.TimeoutExpired as err:
-        raise LambkinSystemdScopeTimeoutError(
+        raise exceptions.LambkinSystemdScopeTimeoutError(
             f"Timed out waiting for scope '{cgroup_scope}' to stop. "
             "Some processes may still be running."
         ) from err
@@ -143,7 +140,7 @@ def main(script: Path, args: tuple) -> None:
         _stop_scope(cgroup_scope)
         sys.exit(130)
     except FileNotFoundError as err:
-        raise LambkinSystemdNotFoundError(
+        raise exceptions.LambkinSystemdNotFoundError(
             "'systemd-run' not found. lambkin requires systemd."
         ) from err
 

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -125,7 +125,7 @@ def main(script: Path, args: tuple) -> None:
 
     signal.signal(signal.SIGINT, _handle_sigint)
     try:
-        result = subprocess.Popen(
+        proc = subprocess.Popen(
             [
                 "systemd-run",
                 "--scope",
@@ -136,7 +136,7 @@ def main(script: Path, args: tuple) -> None:
                 *args,
             ],
         )
-        result.wait()
+        proc.wait()
     except KeyboardInterrupt:
         _stop_scope(cgroup_scope)
         sys.exit(130)
@@ -145,4 +145,4 @@ def main(script: Path, args: tuple) -> None:
             "'systemd-run' not found. lambkin requires systemd."
         ) from err
 
-    sys.exit(result.returncode)
+    sys.exit(proc.returncode)

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -107,6 +107,7 @@ def main(script: Path, args: tuple) -> None:
     # TODO(teresa-ortega): Handle concurrent runs, interrupted benchmarks, and re-runs
     # (e.g. detect an already active scope, support partial restarts).
     # To be addressed in phase 6.
+    script = script.resolve()
     cgroup_scope = f"lambkin-{script.stem}.scope"
 
     try:

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -24,6 +24,7 @@ Typical usage::
     lambkin my_benchmark.py --clock-rate 50 --dry-run
 """
 
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -64,6 +65,28 @@ class LambkinCommand(click.Command):
             formatter.write_text("Run 'lambkin SCRIPT --show-options' to list them.")
 
 
+def _stop_scope(cgroup_scope: str) -> None:
+    """Stop a systemd cgroup scope, waiting up to 30 seconds for it to terminate.
+
+    Parameters
+    ----------
+    cgroup_scope : str
+        The name of the systemd scope to stop.
+    """
+    try:
+        subprocess.run(
+            ["systemctl", "--user", "stop", cgroup_scope],
+            capture_output=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        click.echo(
+            f"Warning: timed out waiting for scope '{cgroup_scope}' to stop. "
+            "Some processes may still be running.",
+            err=True,
+        )
+
+
 @click.command(
     cls=LambkinCommand,
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
@@ -97,8 +120,12 @@ def main(script: Path, args: tuple) -> None:
     # To be addressed in phase 6.
     cgroup_scope = f"lambkin-{script.stem}.scope"
 
+    def _handle_sigint(signum, frame):
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, _handle_sigint)
     try:
-        result = subprocess.run(
+        result = subprocess.Popen(
             [
                 "systemd-run",
                 "--scope",
@@ -109,11 +136,9 @@ def main(script: Path, args: tuple) -> None:
                 *args,
             ],
         )
+        result.wait()
     except KeyboardInterrupt:
-        subprocess.run(
-            ["systemctl", "--user", "stop", "--wait", cgroup_scope],
-            capture_output=True,
-        )
+        _stop_scope(cgroup_scope)
         sys.exit(130)
     except FileNotFoundError as err:
         raise click.ClickException(

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Entry point for the lambkin CLI.
+
+Exposes the ``lambkin`` command, registered as a console script in
+``pyproject.toml``. When invoked, it re-executes the given benchmark
+script under a transient systemd scope so that all child processes
+are placed in a dedicated cgroup v2 hierarchy automatically.
+
+Typical usage::
+
+    lambkin my_benchmark.py --clock-rate 50 --dry-run
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    """Launch a lambkin benchmark script inside a systemd cgroup scope.
+
+    Re-executes ``script`` with the same Python interpreter, wrapped in
+    ``systemd-run --scope`` so that every child process spawned during
+    the benchmark (ROS 2 nodes, bag players, etc.) is placed inside a
+    dedicated transient cgroup v2 scope.  This guarantees that the full
+    process tree can be inspected and killed cleanly without leaving
+    orphaned processes behind.
+
+    The cgroup scope is named ``lambkin-<stem>.scope``, where ``<stem>``
+    is the filename of the script without its extension.  All arguments
+    that follow the script path are forwarded to the child process
+    unchanged, so SDK and user-defined CLI options (e.g. ``--dry-run``,
+    ``--clock-rate``) are passed through transparently.
+
+    Exits with the same return code as the child process.
+
+    Raises:
+    ------
+    SystemExit
+        Always — propagates the child process return code.
+    """
+    if len(sys.argv) < 2:
+        print("Usage: lambkin <script.py> [args...]", file=sys.stderr)
+        sys.exit(1)
+
+    script = Path(sys.argv[1])
+    args = sys.argv[2:]
+
+    cgroup_scope = f"lambkin-{script.stem}.scope"
+
+    result = subprocess.run(
+        [
+            "systemd-run",
+            "--scope",
+            f"--unit={cgroup_scope}",
+            "--user",
+            sys.executable,
+            str(script),
+            *args,
+        ],
+    )
+    sys.exit(result.returncode)

--- a/src/lambkin/common/__init__.py
+++ b/src/lambkin/common/__init__.py
@@ -19,9 +19,12 @@ Provides defaults, named products, and base exceptions.
 
 from lambkin.common import defaults
 
+from .exceptions import LambkinSystemdNotFoundError, LambkinSystemdScopeTimeoutError
 from .named_product import named_product
 
 __all__ = [
     "defaults",
     "named_product",
+    "LambkinSystemdNotFoundError",
+    "LambkinSystemdScopeTimeoutError",
 ]

--- a/src/lambkin/common/__init__.py
+++ b/src/lambkin/common/__init__.py
@@ -17,14 +17,12 @@
 Provides defaults, named products, and base exceptions.
 """
 
-from lambkin.common import defaults
+from lambkin.common import defaults, exceptions
 
-from .exceptions import LambkinSystemdNotFoundError, LambkinSystemdScopeTimeoutError
 from .named_product import named_product
 
 __all__ = [
     "defaults",
     "named_product",
-    "LambkinSystemdNotFoundError",
-    "LambkinSystemdScopeTimeoutError",
+    "exceptions",
 ]

--- a/src/lambkin/common/exceptions.py
+++ b/src/lambkin/common/exceptions.py
@@ -17,3 +17,11 @@
 All errors raised by lambkin inherit from LambkinError, allowing callers to
 catch SDK-specific failures with a single except clause.
 """
+
+
+class LambkinSystemdNotFoundError(Exception):
+    """Raised when systemd-run is not found on the system."""
+
+
+class LambkinSystemdScopeTimeoutError(Exception):
+    """Raised when a systemd scope fails to stop within the timeout period."""

--- a/src/lambkin/common/exceptions.py
+++ b/src/lambkin/common/exceptions.py
@@ -19,9 +19,13 @@ catch SDK-specific failures with a single except clause.
 """
 
 
-class LambkinSystemdNotFoundError(Exception):
+class LambkinError(Exception):
+    """Base class for all lambkin SDK errors."""
+
+
+class LambkinSystemdNotFoundError(LambkinError):
     """Raised when systemd-run is not found on the system."""
 
 
-class LambkinSystemdScopeTimeoutError(Exception):
+class LambkinSystemdScopeTimeoutError(LambkinError):
     """Raised when a systemd scope fails to stop within the timeout period."""

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -42,7 +42,7 @@ from lambkin.sdk_options import SDK_OPTIONS
 def _parse_options(fn, cli_args):
     """Parse CLI options from fn.__lambkin_options__ and return a dict."""
     user_options = getattr(fn, "__lambkin_options__", [])
-    all_options = SDK_OPTIONS + user_options
+    all_options = list(SDK_OPTIONS) + user_options
     if not all_options:
         return {}
     cmd = click.Command(name="benchmark", params=all_options)

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -36,14 +36,16 @@ import click
 from lambkin.core.ctx.context import Context
 from lambkin.core.ctx.source import Source
 from lambkin.core.decorators.input import InputRegistry
+from lambkin.sdk_options import SDK_OPTIONS
 
 
 def _parse_options(fn, cli_args):
     """Parse CLI options from fn.__lambkin_options__ and return a dict."""
-    registered = getattr(fn, "__lambkin_options__", [])
-    if not registered:
+    user_options = getattr(fn, "__lambkin_options__", [])
+    all_options = SDK_OPTIONS + user_options
+    if not all_options:
         return {}
-    cmd = click.Command(name="benchmark", params=registered)
+    cmd = click.Command(name="benchmark", params=all_options)
     click_ctx = cmd.make_context("benchmark", list(cli_args))
     return click_ctx.params
 

--- a/src/lambkin/sdk_options.py
+++ b/src/lambkin/sdk_options.py
@@ -27,7 +27,7 @@ before parsing, so they are always available on ``ctx.options``.
     Reserved options:
         - ``--dry-run``
 
-Typical usage::
+Typical usage:
 
     # ctx.options.dry_run is always available, no @lambkin.option needed
     def my_benchmark(ctx):

--- a/src/lambkin/sdk_options.py
+++ b/src/lambkin/sdk_options.py
@@ -19,6 +19,14 @@ without requiring the user to declare them via ``@lambkin.option``.
 These options are merged with any user-defined options by ``@benchmark``
 before parsing, so they are always available on ``ctx.options``.
 
+.. warning::
+    The option names defined here are reserved. Declaring any of them
+    via ``@lambkin.option`` in user benchmarks will raise a Click error
+    at parse time due to duplicate parameter names.
+
+    Reserved options:
+        - ``--dry-run``
+
 Typical usage::
 
     # ctx.options.dry_run is always available, no @lambkin.option needed
@@ -28,11 +36,11 @@ Typical usage::
 
 import click
 
-SDK_OPTIONS: list[click.Option] = [
+SDK_OPTIONS: tuple[click.Option, ...] = (
     click.Option(
         ["--dry-run"],
         is_flag=True,
         default=False,
-        help="Print commands without executing them.",
+        help="Run the benchmark in dry-run mode: commands are logged but not executed.",
     ),
-]
+)

--- a/src/lambkin/sdk_options.py
+++ b/src/lambkin/sdk_options.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SDK-level CLI options exposed natively by lambkin.
+
+Defines the set of CLI options that lambkin provides out of the box,
+without requiring the user to declare them via ``@lambkin.option``.
+These options are merged with any user-defined options by ``@benchmark``
+before parsing, so they are always available on ``ctx.options``.
+
+Typical usage::
+
+    # ctx.options.dry_run is always available, no @lambkin.option needed
+    def my_benchmark(ctx):
+        ctx.options.dry_run
+"""
+
+import click
+
+SDK_OPTIONS: list[click.Option] = [
+    click.Option(
+        ["--dry-run"],
+        is_flag=True,
+        default=False,
+        help="Print commands without executing them.",
+    ),
+]

--- a/src/lambkin/sdk_options.py
+++ b/src/lambkin/sdk_options.py
@@ -40,7 +40,8 @@ SDK_OPTIONS: tuple[click.Option, ...] = (
     click.Option(
         ["--dry-run"],
         is_flag=True,
-        default=False,
+        show_default=True,
+        default=True,
         help="Run the benchmark in dry-run mode: commands are logged but not executed.",
     ),
 )

--- a/src/lambkin/sdk_options.py
+++ b/src/lambkin/sdk_options.py
@@ -41,7 +41,7 @@ SDK_OPTIONS: tuple[click.Option, ...] = (
         ["--dry-run"],
         is_flag=True,
         show_default=True,
-        default=True,
+        default=False,
         help="Run the benchmark in dry-run mode: commands are logged but not executed.",
     ),
 )

--- a/src/lambkin/sdk_options.py
+++ b/src/lambkin/sdk_options.py
@@ -36,12 +36,14 @@ Typical usage:
 
 import click
 
+from lambkin.common import defaults
+
 SDK_OPTIONS: tuple[click.Option, ...] = (
     click.Option(
         ["--dry-run"],
         is_flag=True,
         show_default=True,
-        default=False,
+        default=defaults.DRY_RUN,
         help="Run the benchmark in dry-run mode: commands are logged but not executed.",
     ),
 )

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -41,7 +41,7 @@ def test_parse_options_returns_empty_dict_when_no_options():
         pass
 
     result = _parse_options(fn, [])
-    assert result == {}
+    assert result == {"dry_run": False}
 
 
 def test_parse_options_returns_defaults_when_no_args():
@@ -53,7 +53,7 @@ def test_parse_options_returns_defaults_when_no_args():
         pass
 
     result = _parse_options(fn, [])
-    assert result == {"clock_rate": 100.0, "sensor_topic": "/scan"}
+    assert result == {"dry_run": False, "clock_rate": 100.0, "sensor_topic": "/scan"}
 
 
 def test_parse_options_returns_cli_values_when_provided():
@@ -65,7 +65,7 @@ def test_parse_options_returns_cli_values_when_provided():
         pass
 
     result = _parse_options(fn, ["--clock-rate", "50.0"])
-    assert result == {"clock_rate": 50.0, "sensor_topic": "/scan"}
+    assert result == {"dry_run": False, "clock_rate": 50.0, "sensor_topic": "/scan"}
 
 
 def test_benchmark_preserves_metadata(variants, tmp_path):

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -177,3 +177,24 @@ def test_benchmark_empty_variants_raises_error(tmp_path):
         @benchmark(variants=[], num_iterations=1)
         def fn(ctx):
             pass
+
+
+def test_parse_options_includes_dry_run_by_default():
+    """_parse_options always includes dry_run even when no user options are declared."""
+
+    def fn(ctx):
+        pass
+
+    result = _parse_options(fn, [])
+    assert "dry_run" in result
+    assert result["dry_run"] is False
+
+
+def test_parse_options_dry_run_can_be_set_via_cli():
+    """_parse_options returns dry_run=True when --dry-run is passed."""
+
+    def fn(ctx):
+        pass
+
+    result = _parse_options(fn, ["--dry-run"])
+    assert result["dry_run"] is True

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 
 import pytest
 
+from lambkin.common import defaults
 from lambkin.core.ctx.context import Context
 from lambkin.core.ctx.source import Source
 from lambkin.core.decorators.benchmark import _parse_options, benchmark
@@ -41,7 +42,7 @@ def test_parse_options_returns_empty_dict_when_no_options():
         pass
 
     result = _parse_options(fn, [])
-    assert result == {"dry_run": False}
+    assert result == {"dry_run": defaults.DRY_RUN}
 
 
 def test_parse_options_returns_defaults_when_no_args():
@@ -53,7 +54,11 @@ def test_parse_options_returns_defaults_when_no_args():
         pass
 
     result = _parse_options(fn, [])
-    assert result == {"dry_run": False, "clock_rate": 100.0, "sensor_topic": "/scan"}
+    assert result == {
+        "dry_run": defaults.DRY_RUN,
+        "clock_rate": 100.0,
+        "sensor_topic": "/scan",
+    }
 
 
 def test_parse_options_returns_cli_values_when_provided():
@@ -65,7 +70,11 @@ def test_parse_options_returns_cli_values_when_provided():
         pass
 
     result = _parse_options(fn, ["--clock-rate", "50.0"])
-    assert result == {"dry_run": False, "clock_rate": 50.0, "sensor_topic": "/scan"}
+    assert result == {
+        "dry_run": defaults.DRY_RUN,
+        "clock_rate": 50.0,
+        "sensor_topic": "/scan",
+    }
 
 
 def test_benchmark_preserves_metadata(variants, tmp_path):
@@ -187,7 +196,7 @@ def test_parse_options_includes_dry_run_by_default():
 
     result = _parse_options(fn, [])
     assert "dry_run" in result
-    assert result["dry_run"] is False
+    assert result["dry_run"] is defaults.DRY_RUN
 
 
 def test_parse_options_dry_run_can_be_set_via_cli():

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -72,3 +72,13 @@ def test_keyboard_interrupt_stops_scope(dummy_script):
     assert result.exit_code == 130
     calls = mock_run.call_args_list
     assert "stop" in calls[1][0][0]
+
+
+def test_help_output_contains_expected_sections():
+    """Help output contains the expected sections."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "SDK Options (always available)" in result.output
+    assert "Custom Options (script-defined)" in result.output
+    assert "--dry-run" in result.output

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the lambkin CLI entry point."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lambkin.cli import main
+
+
+@pytest.fixture
+def dummy_script(tmp_path):
+    """Create a minimal valid benchmark script."""
+    script = tmp_path / "bench.py"
+    script.write_text("# dummy benchmark")
+    return script
+
+
+def test_missing_script_argument(capsys):
+    """Exits with code 2 (argparse default) if no script is given."""
+    with patch("sys.argv", ["lambkin"]):
+        with pytest.raises(SystemExit) as exc:
+            main()
+    assert exc.value.code == 2
+
+
+def test_script_not_found(capsys):
+    """Exits with code 1 and prints a clear error if script does not exist."""
+    with patch("sys.argv", ["lambkin", "/nonexistent/bench.py"]):
+        with pytest.raises(SystemExit) as exc:
+            main()
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "not found" in captured.err
+
+
+def test_relative_path_is_resolved(tmp_path, monkeypatch, dummy_script):
+    """Script path is resolved to absolute before use."""
+    monkeypatch.chdir(tmp_path)
+    with patch("sys.argv", ["lambkin", "bench.py"]):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+
+            mock_run.side_effect = [
+                MagicMock(returncode=1),
+                MagicMock(returncode=0),
+            ]
+            with pytest.raises(SystemExit):
+                main()
+
+    systemd_call = mock_run.call_args_list[1]
+    cmd = systemd_call[0][0]
+    assert str(dummy_script) in cmd
+
+
+def test_systemd_not_found(capsys, dummy_script):
+    """Exits with code 127 and prints a clear error if systemd-run is missing."""
+    with patch("sys.argv", ["lambkin", str(dummy_script)]):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=1),
+                FileNotFoundError,
+            ]
+            with pytest.raises(SystemExit) as exc:
+                main()
+    assert exc.value.code == 127
+    captured = capsys.readouterr()
+    assert "systemd" in captured.err
+
+
+def test_scope_already_active_without_overwrite(capsys, dummy_script):
+    """Exits with code 1 and clear error if scope is active and --overwrite not set."""
+    with patch("sys.argv", ["lambkin", str(dummy_script)]):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            with pytest.raises(SystemExit) as exc:
+                main()
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "overwrite" in captured.err
+
+
+def test_scope_already_active_with_overwrite(dummy_script):
+    """With --overwrite, stops existing scope and re-launches."""
+    with patch("sys.argv", ["lambkin", str(dummy_script), "--overwrite"]):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0),
+                MagicMock(returncode=0),
+                MagicMock(returncode=0),
+            ]
+            with pytest.raises(SystemExit):
+                main()
+    calls = mock_run.call_args_list
+    assert "stop" in calls[1][0][0]
+
+
+def test_keyboard_interrupt_stops_scope(dummy_script):
+    """Ctrl-C stops the cgroup scope before exiting with code 130."""
+    with patch("sys.argv", ["lambkin", str(dummy_script)]):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=1),
+                KeyboardInterrupt,
+                MagicMock(returncode=0),
+            ]
+            with pytest.raises(SystemExit) as exc:
+                main()
+    assert exc.value.code == 130
+    calls = mock_run.call_args_list
+    assert "stop" in calls[2][0][0]

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -30,11 +30,11 @@ def dummy_script(tmp_path):
 
 
 def test_missing_script_argument(capsys):
-    """Exits with code 2 (argparse default) if no script is given."""
+    """Exits with code 1 if no script is given."""
     with patch("sys.argv", ["lambkin"]):
         with pytest.raises(SystemExit) as exc:
             main()
-    assert exc.value.code == 2
+    assert exc.value.code == 1
 
 
 def test_script_not_found(capsys):
@@ -53,27 +53,16 @@ def test_relative_path_is_resolved(tmp_path, monkeypatch, dummy_script):
     with patch("sys.argv", ["lambkin", "bench.py"]):
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-
-            mock_run.side_effect = [
-                MagicMock(returncode=1),
-                MagicMock(returncode=0),
-            ]
             with pytest.raises(SystemExit):
                 main()
-
-    systemd_call = mock_run.call_args_list[1]
-    cmd = systemd_call[0][0]
-    assert str(dummy_script) in cmd
+            cmd = mock_run.call_args[0][0]
+            assert str(dummy_script) in cmd
 
 
 def test_systemd_not_found(capsys, dummy_script):
     """Exits with code 127 and prints a clear error if systemd-run is missing."""
     with patch("sys.argv", ["lambkin", str(dummy_script)]):
-        with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = [
-                MagicMock(returncode=1),
-                FileNotFoundError,
-            ]
+        with patch("subprocess.run", side_effect=FileNotFoundError):
             with pytest.raises(SystemExit) as exc:
                 main()
     assert exc.value.code == 127
@@ -81,44 +70,13 @@ def test_systemd_not_found(capsys, dummy_script):
     assert "systemd" in captured.err
 
 
-def test_scope_already_active_without_overwrite(capsys, dummy_script):
-    """Exits with code 1 and clear error if scope is active and --overwrite not set."""
-    with patch("sys.argv", ["lambkin", str(dummy_script)]):
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
-            with pytest.raises(SystemExit) as exc:
-                main()
-    assert exc.value.code == 1
-    captured = capsys.readouterr()
-    assert "overwrite" in captured.err
-
-
-def test_scope_already_active_with_overwrite(dummy_script):
-    """With --overwrite, stops existing scope and re-launches."""
-    with patch("sys.argv", ["lambkin", str(dummy_script), "--overwrite"]):
-        with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = [
-                MagicMock(returncode=0),
-                MagicMock(returncode=0),
-                MagicMock(returncode=0),
-            ]
-            with pytest.raises(SystemExit):
-                main()
-    calls = mock_run.call_args_list
-    assert "stop" in calls[1][0][0]
-
-
 def test_keyboard_interrupt_stops_scope(dummy_script):
     """Ctrl-C stops the cgroup scope before exiting with code 130."""
     with patch("sys.argv", ["lambkin", str(dummy_script)]):
         with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = [
-                MagicMock(returncode=1),
-                KeyboardInterrupt,
-                MagicMock(returncode=0),
-            ]
+            mock_run.side_effect = [KeyboardInterrupt, MagicMock(returncode=0)]
             with pytest.raises(SystemExit) as exc:
                 main()
     assert exc.value.code == 130
     calls = mock_run.call_args_list
-    assert "stop" in calls[2][0][0]
+    assert "stop" in calls[1][0][0]

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -44,13 +44,12 @@ def test_script_not_found():
     assert result.exit_code == 2
 
 
-def test_relative_path_is_resolved(tmp_path, monkeypatch, dummy_script):
-    """Script path is resolved to absolute before use."""
-    monkeypatch.chdir(tmp_path)
+def test_absolute_path_is_passed_to_subprocess(dummy_script):
+    """Script absolute path is forwarded to the subprocess."""
     runner = CliRunner()
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0)
-        runner.invoke(main, ["bench.py"])
+        runner.invoke(main, [str(dummy_script)])
         cmd = mock_run.call_args[0][0]
         assert str(dummy_script) in cmd
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -47,17 +47,17 @@ def test_script_not_found():
 def test_absolute_path_is_passed_to_subprocess(dummy_script):
     """Script absolute path is forwarded to the subprocess."""
     runner = CliRunner()
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0)
+    with patch("subprocess.Popen") as mock_popen:
+        mock_popen.return_value = MagicMock(returncode=0)
         runner.invoke(main, [str(dummy_script)])
-        cmd = mock_run.call_args[0][0]
+        cmd = mock_popen.call_args[0][0]
         assert str(dummy_script) in cmd
 
 
 def test_systemd_not_found(dummy_script):
     """Exits with error if systemd-run is missing."""
     runner = CliRunner()
-    with patch("subprocess.run", side_effect=FileNotFoundError):
+    with patch("subprocess.Popen", side_effect=FileNotFoundError):
         result = runner.invoke(main, [str(dummy_script)])
     assert result.exit_code != 0
     assert "systemd" in result.output
@@ -66,12 +66,15 @@ def test_systemd_not_found(dummy_script):
 def test_keyboard_interrupt_stops_scope(dummy_script):
     """Ctrl-C stops the cgroup scope before exiting with code 130."""
     runner = CliRunner()
-    with patch("subprocess.run") as mock_run:
-        mock_run.side_effect = [KeyboardInterrupt, MagicMock(returncode=0)]
-        result = runner.invoke(main, [str(dummy_script)])
+    with patch("subprocess.Popen") as mock_popen:
+        mock_proc = MagicMock()
+        mock_proc.wait.side_effect = KeyboardInterrupt
+        mock_popen.return_value = mock_proc
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = runner.invoke(main, [str(dummy_script)])
     assert result.exit_code == 130
-    calls = mock_run.call_args_list
-    assert "stop" in calls[1][0][0]
+    assert "stop" in mock_run.call_args[0][0]
 
 
 def test_help_output_contains_expected_sections():

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -60,7 +60,7 @@ def test_systemd_not_found(dummy_script):
     with patch("subprocess.Popen", side_effect=FileNotFoundError):
         result = runner.invoke(main, [str(dummy_script)])
     assert result.exit_code != 0
-    assert "systemd" in result.output
+    assert "systemd" in str(result.exception)
 
 
 def test_keyboard_interrupt_stops_scope(dummy_script):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -17,6 +17,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 
 from lambkin.cli import main
 
@@ -29,54 +30,46 @@ def dummy_script(tmp_path):
     return script
 
 
-def test_missing_script_argument(capsys):
-    """Exits with code 1 if no script is given."""
-    with patch("sys.argv", ["lambkin"]):
-        with pytest.raises(SystemExit) as exc:
-            main()
-    assert exc.value.code == 1
+def test_missing_script_argument():
+    """Exits with code 2 if no script is given."""
+    runner = CliRunner()
+    result = runner.invoke(main, [])
+    assert result.exit_code == 2
 
 
-def test_script_not_found(capsys):
-    """Exits with code 1 and prints a clear error if script does not exist."""
-    with patch("sys.argv", ["lambkin", "/nonexistent/bench.py"]):
-        with pytest.raises(SystemExit) as exc:
-            main()
-    assert exc.value.code == 1
-    captured = capsys.readouterr()
-    assert "not found" in captured.err
+def test_script_not_found():
+    """Exits with code 2 if script does not exist."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["/nonexistent/bench.py"])
+    assert result.exit_code == 2
 
 
 def test_relative_path_is_resolved(tmp_path, monkeypatch, dummy_script):
     """Script path is resolved to absolute before use."""
     monkeypatch.chdir(tmp_path)
-    with patch("sys.argv", ["lambkin", "bench.py"]):
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
-            with pytest.raises(SystemExit):
-                main()
-            cmd = mock_run.call_args[0][0]
-            assert str(dummy_script) in cmd
+    runner = CliRunner()
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        runner.invoke(main, ["bench.py"])
+        cmd = mock_run.call_args[0][0]
+        assert str(dummy_script) in cmd
 
 
-def test_systemd_not_found(capsys, dummy_script):
-    """Exits with code 127 and prints a clear error if systemd-run is missing."""
-    with patch("sys.argv", ["lambkin", str(dummy_script)]):
-        with patch("subprocess.run", side_effect=FileNotFoundError):
-            with pytest.raises(SystemExit) as exc:
-                main()
-    assert exc.value.code == 127
-    captured = capsys.readouterr()
-    assert "systemd" in captured.err
+def test_systemd_not_found(dummy_script):
+    """Exits with error if systemd-run is missing."""
+    runner = CliRunner()
+    with patch("subprocess.run", side_effect=FileNotFoundError):
+        result = runner.invoke(main, [str(dummy_script)])
+    assert result.exit_code != 0
+    assert "systemd" in result.output
 
 
 def test_keyboard_interrupt_stops_scope(dummy_script):
     """Ctrl-C stops the cgroup scope before exiting with code 130."""
-    with patch("sys.argv", ["lambkin", str(dummy_script)]):
-        with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = [KeyboardInterrupt, MagicMock(returncode=0)]
-            with pytest.raises(SystemExit) as exc:
-                main()
-    assert exc.value.code == 130
+    runner = CliRunner()
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [KeyboardInterrupt, MagicMock(returncode=0)]
+        result = runner.invoke(main, [str(dummy_script)])
+    assert result.exit_code == 130
     calls = mock_run.call_args_list
     assert "stop" in calls[1][0][0]


### PR DESCRIPTION
### Proposed changes

Exposes lambkin as a CLI command via a console script entry point. The main() function in cli.py wraps benchmark script execution inside a systemd-run --scope so that all child processes are placed in a dedicated cgroup v2 scope automatically, without requiring the user to do anything.

Adds sdk_options.py to define SDK-level CLI options like --dry-run that are always available on ctx.options without the user having to declare them via @lambkin.option. These are merged with user-defined options in _parse_options() inside benchmark.py.

Implemented the --help flag for lambkin, which now displays usage information and available options when the CLI is invoked with uv run lambkin --help.

#### How to test
1. Re-install the lambkin package:
```bash
uv sync
```
2. Run lambkin in --help mode:
```bash
uv run lambkin --help
```

3. Run the benchmark script:
```bash
uv run lambkin examples/beluga/beluga_benchmark.py
```

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments

N/A