### PR TITLE
Adds --show-options to the lambkin CLI

### DIFF
--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -23,7 +23,6 @@ Typical usage:
     lambkin my_benchmark.py --clock-rate 50 --dry-run
 """
 
-import importlib.util
 import signal
 import subprocess
 import sys
@@ -64,40 +63,6 @@ class LambkinCommand(click.Command):
                 "Options registered in your benchmark script via @lambkin.option."
             )
             formatter.write_text("Run 'lambkin SCRIPT --show-options' to list them.")
-
-
-def _show_options(script: Path) -> None:
-    """Load the benchmark script and print all registered @lambkin.option entries."""
-    spec = importlib.util.spec_from_file_location("_lambkin_user_script", script)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-
-    options = []
-    for name in dir(module):
-        obj = getattr(module, name)
-        if callable(obj) and hasattr(obj, "__lambkin_options__"):
-            options.extend(obj.__lambkin_options__)
-
-    formatter = HelpFormatter()
-    if not options:
-        formatter.write_text("No options registered in this script.")
-    else:
-        with formatter.section("Custom Options"):
-            formatter.write_dl(
-                [
-                    (
-                        opt.opts[0],
-                        (opt.help or "")
-                        + (
-                            f"  [default: {opt.default}]"
-                            if opt.default is not None
-                            else ""
-                        ),
-                    )
-                    for opt in options
-                ]
-            )
-    click.echo(formatter.getvalue(), nl=False)
 
 
 def _stop_scope(cgroup_scope: str) -> None:
@@ -152,9 +117,6 @@ def main(script: Path, args: tuple) -> None:
     # TODO(teresa-ortega): Handle concurrent runs, interrupted benchmarks, and re-runs
     # (e.g. detect an already active scope, support partial restarts).
     # To be addressed in phase 6.
-    if "--show-options" in args:
-        _show_options(script)
-        sys.exit(0)
 
     cgroup_scope = f"lambkin-{script.stem}.scope"
 

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -23,6 +23,7 @@ Typical usage:
     lambkin my_benchmark.py --clock-rate 50 --dry-run
 """
 
+import importlib.util
 import signal
 import subprocess
 import sys
@@ -63,6 +64,40 @@ class LambkinCommand(click.Command):
                 "Options registered in your benchmark script via @lambkin.option."
             )
             formatter.write_text("Run 'lambkin SCRIPT --show-options' to list them.")
+
+
+def _show_options(script: Path) -> None:
+    """Load the benchmark script and print all registered @lambkin.option entries."""
+    spec = importlib.util.spec_from_file_location("_lambkin_user_script", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    options = []
+    for name in dir(module):
+        obj = getattr(module, name)
+        if callable(obj) and hasattr(obj, "__lambkin_options__"):
+            options.extend(obj.__lambkin_options__)
+
+    formatter = HelpFormatter()
+    if not options:
+        formatter.write_text("No options registered in this script.")
+    else:
+        with formatter.section("Custom Options"):
+            formatter.write_dl(
+                [
+                    (
+                        opt.opts[0],
+                        (opt.help or "")
+                        + (
+                            f"  [default: {opt.default}]"
+                            if opt.default is not None
+                            else ""
+                        ),
+                    )
+                    for opt in options
+                ]
+            )
+    click.echo(formatter.getvalue(), nl=False)
 
 
 def _stop_scope(cgroup_scope: str) -> None:
@@ -117,6 +152,10 @@ def main(script: Path, args: tuple) -> None:
     # TODO(teresa-ortega): Handle concurrent runs, interrupted benchmarks, and re-runs
     # (e.g. detect an already active scope, support partial restarts).
     # To be addressed in phase 6.
+    if "--show-options" in args:
+        _show_options(script)
+        sys.exit(0)
+
     cgroup_scope = f"lambkin-{script.stem}.scope"
 
     def _handle_sigint(signum, frame):

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -32,6 +32,7 @@ import inspect
 import sys
 
 import click
+from click.formatting import HelpFormatter
 
 from lambkin.core.ctx.context import Context
 from lambkin.core.ctx.source import Source
@@ -40,9 +41,7 @@ from lambkin.sdk_options import SDK_OPTIONS
 
 
 def _show_options(fn) -> None:
-    """Print all options registered via @lambkin.option on fn and exit."""
-    from click.formatting import HelpFormatter
-
+    """Print all options registered via @lambkin.option on fn."""
     user_options = getattr(fn, "__lambkin_options__", [])
     formatter = HelpFormatter()
     if not user_options:

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -44,10 +44,12 @@ def _show_options(fn) -> None:
     """Print all options registered via @lambkin.option on fn."""
     user_options = getattr(fn, "__lambkin_options__", [])
     formatter = HelpFormatter()
-    if not user_options:
-        formatter.write_text("No options registered in this script.")
-    else:
-        with formatter.section("Custom Options"):
+    with formatter.section("SDK Options"):
+        formatter.write_dl([(opt.opts[0], opt.help or "") for opt in SDK_OPTIONS])
+    with formatter.section("Custom Options"):
+        if not user_options:
+            formatter.write_text("No options registered in this script.")
+        else:
             formatter.write_dl(
                 [
                     (

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -39,6 +39,18 @@ from lambkin.core.decorators.input import InputRegistry
 from lambkin.sdk_options import SDK_OPTIONS
 
 
+def _show_options(fn) -> None:
+    """Print all options registered via @lambkin.option on fn and exit."""
+    user_options = getattr(fn, "__lambkin_options__", [])
+    if not user_options:
+        print("No options registered in this script.")
+    else:
+        print("Custom Options:")
+        for opt in user_options:
+            default = f"  [default: {opt.default}]" if opt.default is not None else ""
+            print(f"  {opt.opts[0]:<30} {opt.help or ''}{default}")
+
+
 def _parse_options(fn, cli_args):
     """Parse CLI options from fn.__lambkin_options__ and return a dict."""
     user_options = getattr(fn, "__lambkin_options__", [])
@@ -85,6 +97,9 @@ def benchmark(variants, num_iterations):
         def wrapper(args=None, output_dir=None):
             cli_args = sys.argv[1:] if args is None else args
             options = _parse_options(fn, cli_args)
+            if options.get("show_options"):
+                _show_options(fn)
+                sys.exit(0)
             source = Source(path=inspect.getfile(fn))
             # The base context creates a directory for variant 1 / iteration 1
             # containing a metadata file with the information available at this

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -41,14 +41,29 @@ from lambkin.sdk_options import SDK_OPTIONS
 
 def _show_options(fn) -> None:
     """Print all options registered via @lambkin.option on fn and exit."""
+    from click.formatting import HelpFormatter
+
     user_options = getattr(fn, "__lambkin_options__", [])
+    formatter = HelpFormatter()
     if not user_options:
-        print("No options registered in this script.")
+        formatter.write_text("No options registered in this script.")
     else:
-        print("Custom Options:")
-        for opt in user_options:
-            default = f"  [default: {opt.default}]" if opt.default is not None else ""
-            print(f"  {opt.opts[0]:<30} {opt.help or ''}{default}")
+        with formatter.section("Custom Options"):
+            formatter.write_dl(
+                [
+                    (
+                        opt.opts[0],
+                        (opt.help or "")
+                        + (
+                            f"  [default: {opt.default}]"
+                            if opt.default is not None
+                            else ""
+                        ),
+                    )
+                    for opt in user_options
+                ]
+            )
+    click.echo(formatter.getvalue(), nl=False)
 
 
 def _parse_options(fn, cli_args):

--- a/src/lambkin/sdk_options.py
+++ b/src/lambkin/sdk_options.py
@@ -28,13 +28,6 @@ before parsing, so they are always available on ``ctx.options``.
         - ``--dry-run``
         - ``--show-options``
 
-Typical usage::
-
-    # ctx.options.dry_run is always available, no @lambkin.option needed
-    def my_benchmark(ctx):
-        if ctx.options.dry_run:
-            ...
-
 Note:
     ``--show-options`` behaves like ``--help``: it prints registered
     options and exits immediately, never reaching the benchmark body.

--- a/src/lambkin/sdk_options.py
+++ b/src/lambkin/sdk_options.py
@@ -26,12 +26,18 @@ before parsing, so they are always available on ``ctx.options``.
 
     Reserved options:
         - ``--dry-run``
+        - ``--show-options``
 
-Typical usage:
+Typical usage::
 
     # ctx.options.dry_run is always available, no @lambkin.option needed
     def my_benchmark(ctx):
-        ctx.options.dry_run
+        if ctx.options.dry_run:
+            ...
+
+Note:
+    ``--show-options`` behaves like ``--help``: it prints registered
+    options and exits immediately, never reaching the benchmark body.
 """
 
 import click
@@ -45,5 +51,12 @@ SDK_OPTIONS: tuple[click.Option, ...] = (
         show_default=True,
         default=defaults.DRY_RUN,
         help="Run the benchmark in dry-run mode: commands are logged but not executed.",
+    ),
+    click.Option(
+        ["--show-options"],
+        is_flag=True,
+        show_default=True,
+        default=False,
+        help="List all options registered via @lambkin.option.",
     ),
 )

--- a/src/lambkin/sdk_options.py
+++ b/src/lambkin/sdk_options.py
@@ -48,7 +48,6 @@ SDK_OPTIONS: tuple[click.Option, ...] = (
     click.Option(
         ["--show-options"],
         is_flag=True,
-        show_default=True,
         default=False,
         help="List all options registered via @lambkin.option.",
     ),

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -42,7 +42,10 @@ def test_parse_options_returns_empty_dict_when_no_options():
         pass
 
     result = _parse_options(fn, [])
-    assert result == {"dry_run": defaults.DRY_RUN}
+    assert result == {
+        "dry_run": defaults.DRY_RUN,
+        "show_options": False,
+    }
 
 
 def test_parse_options_returns_defaults_when_no_args():
@@ -56,6 +59,7 @@ def test_parse_options_returns_defaults_when_no_args():
     result = _parse_options(fn, [])
     assert result == {
         "dry_run": defaults.DRY_RUN,
+        "show_options": False,
         "clock_rate": 100.0,
         "sensor_topic": "/scan",
     }
@@ -72,6 +76,7 @@ def test_parse_options_returns_cli_values_when_provided():
     result = _parse_options(fn, ["--clock-rate", "50.0"])
     assert result == {
         "dry_run": defaults.DRY_RUN,
+        "show_options": False,
         "clock_rate": 50.0,
         "sensor_topic": "/scan",
     }

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -212,3 +212,35 @@ def test_parse_options_dry_run_can_be_set_via_cli():
 
     result = _parse_options(fn, ["--dry-run"])
     assert result["dry_run"] is True
+
+
+def test_show_options_no_options_registered(capsys):
+    """No @lambkin.option shows a 'no options' message."""
+
+    @benchmark(variants=[{}], num_iterations=1)
+    def fn(ctx):
+        pass
+
+    with pytest.raises(SystemExit) as exc:
+        fn(args=["--show-options"])
+
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert "No options registered in this script." in captured.out
+
+
+def test_show_options_displays_registered_options(capsys):
+    """@lambkin.option entries are shown with name and default."""
+
+    @benchmark(variants=[{}], num_iterations=1)
+    @option("--clock-rate", default=100.0)
+    def fn(ctx):
+        pass
+
+    with pytest.raises(SystemExit) as exc:
+        fn(args=["--show-options"])
+
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert "--clock-rate" in captured.out
+    assert "100.0" in captured.out

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -19,7 +19,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+import lambkin
 from lambkin.cli import main
+from lambkin.core.decorators.benchmark import _show_options
 
 
 @pytest.fixture
@@ -87,41 +89,37 @@ def test_help_output_contains_expected_sections():
     assert "--dry-run" in result.output
 
 
-def test_show_options_no_options_registered(tmp_path):
-    """Script with no @lambkin.option shows a 'no options' message."""
-    script = tmp_path / "bench.py"
-    script.write_text("# dummy benchmark")
+def test_show_options_no_options_registered(tmp_path, capsys):
+    """No @lambkin.option shows a 'no options' message."""
 
-    runner = CliRunner()
-    result = runner.invoke(main, [str(script), "--show-options"])
+    def fn(ctx):
+        pass
 
-    assert result.exit_code == 0
-    assert "No options registered in this script." in result.output
+    _show_options(fn)
 
-
-def test_show_options_displays_registered_options(tmp_path):
-    """Script with @lambkin.option shows name, help and default."""
-    script = tmp_path / "bench.py"
-    script.write_text(
-        "import lambkin\n"
-        "@lambkin.option('--clock-rate', default=100.0)\n"
-        "def my_benchmark(ctx): pass\n"
-    )
-
-    runner = CliRunner()
-    result = runner.invoke(main, [str(script), "--show-options"])
-
-    assert result.exit_code == 0
-    assert "--clock-rate" in result.output
-    assert "100.0" in result.output
+    captured = capsys.readouterr()
+    assert "No options registered in this script." in captured.out
 
 
-def test_show_options_does_not_reach_systemd(tmp_path):
-    """--show-options exits before launching systemd-run."""
-    script = tmp_path / "bench.py"
-    script.write_text("# dummy benchmark")
+def test_show_options_displays_registered_options(capsys):
+    """@lambkin.option entries are shown with name and default."""
 
+    @lambkin.option("--clock-rate", default=100.0)
+    def fn(ctx):
+        pass
+
+    _show_options(fn)
+
+    captured = capsys.readouterr()
+    assert "--clock-rate" in captured.out
+    assert "100.0" in captured.out
+
+
+def test_show_options_does_not_reach_systemd(dummy_script):
+    """--show-options is forwarded to subprocess like any other SDK option."""
     runner = CliRunner()
     with patch("subprocess.Popen") as mock_popen:
-        runner.invoke(main, [str(script), "--show-options"])
-        mock_popen.assert_not_called()
+        mock_popen.return_value = MagicMock(returncode=0)
+        runner.invoke(main, [str(dummy_script), "--show-options"])
+        cmd = mock_popen.call_args[0][0]
+        assert "--show-options" in cmd

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -85,3 +85,43 @@ def test_help_output_contains_expected_sections():
     assert "SDK Options (always available)" in result.output
     assert "Custom Options (script-defined)" in result.output
     assert "--dry-run" in result.output
+
+
+def test_show_options_no_options_registered(tmp_path):
+    """Script with no @lambkin.option shows a 'no options' message."""
+    script = tmp_path / "bench.py"
+    script.write_text("# dummy benchmark")
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(script), "--show-options"])
+
+    assert result.exit_code == 0
+    assert "No options registered in this script." in result.output
+
+
+def test_show_options_displays_registered_options(tmp_path):
+    """Script with @lambkin.option shows name, help and default."""
+    script = tmp_path / "bench.py"
+    script.write_text(
+        "import lambkin\n"
+        "@lambkin.option('--clock-rate', default=100.0)\n"
+        "def my_benchmark(ctx): pass\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, [str(script), "--show-options"])
+
+    assert result.exit_code == 0
+    assert "--clock-rate" in result.output
+    assert "100.0" in result.output
+
+
+def test_show_options_does_not_reach_systemd(tmp_path):
+    """--show-options exits before launching systemd-run."""
+    script = tmp_path / "bench.py"
+    script.write_text("# dummy benchmark")
+
+    runner = CliRunner()
+    with patch("subprocess.Popen") as mock_popen:
+        runner.invoke(main, [str(script), "--show-options"])
+        mock_popen.assert_not_called()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -19,9 +19,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-import lambkin
 from lambkin.cli import main
-from lambkin.core.decorators.benchmark import _show_options
 
 
 @pytest.fixture
@@ -87,39 +85,3 @@ def test_help_output_contains_expected_sections():
     assert "SDK Options (always available)" in result.output
     assert "Custom Options (script-defined)" in result.output
     assert "--dry-run" in result.output
-
-
-def test_show_options_no_options_registered(tmp_path, capsys):
-    """No @lambkin.option shows a 'no options' message."""
-
-    def fn(ctx):
-        pass
-
-    _show_options(fn)
-
-    captured = capsys.readouterr()
-    assert "No options registered in this script." in captured.out
-
-
-def test_show_options_displays_registered_options(capsys):
-    """@lambkin.option entries are shown with name and default."""
-
-    @lambkin.option("--clock-rate", default=100.0)
-    def fn(ctx):
-        pass
-
-    _show_options(fn)
-
-    captured = capsys.readouterr()
-    assert "--clock-rate" in captured.out
-    assert "100.0" in captured.out
-
-
-def test_show_options_does_not_reach_systemd(dummy_script):
-    """--show-options is forwarded to subprocess like any other SDK option."""
-    runner = CliRunner()
-    with patch("subprocess.Popen") as mock_popen:
-        mock_popen.return_value = MagicMock(returncode=0)
-        runner.invoke(main, [str(dummy_script), "--show-options"])
-        cmd = mock_popen.call_args[0][0]
-        assert "--show-options" in cmd


### PR DESCRIPTION
### Proposed changes

When passed after a script, it imports the script without executing it and prints all options registered via `@lambkin.option`, then exits. 

Builds on top of :
* #152 

#### How to test
1. Re-install the lambkin package:
```bash
uv sync
```

2. Run the benchmark script with --show-options
```
uv run lambkin examples/beluga/beluga_benchmark.py --show-options
```

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments

N/A
