### PR TITLE
Standardize docstrings to Google style

### DIFF
--- a/examples/beluga/beluga_ros2/launch/beluga.launch.py
+++ b/examples/beluga/beluga_ros2/launch/beluga.launch.py
@@ -86,14 +86,12 @@ def generate_launch_description():
         parameters=[{"autostart": True, "node_names": ["map_server", "beluga_amcl"]}],
     )
 
-    return LaunchDescription(
-        [
-            config_file_arg,
-            map_path_arg,
-            laser_model_arg,
-            max_particles_arg,
-            beluga_node,
-            map_server_node,
-            lifecycle_manager_node,
-        ]
-    )
+    return LaunchDescription([
+        config_file_arg,
+        map_path_arg,
+        laser_model_arg,
+        max_particles_arg,
+        beluga_node,
+        map_server_node,
+        lifecycle_manager_node,
+    ])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,17 @@ python_version = "3.10"
 [tool.ruff]
 line-length = 88
 target-version = "py310"
+preview = true
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "D", "N", "UP", "B"]
+select = ["E", "W", "F", "I", "D", "DOC"]
+extend-select = ["D101", "D102", "D103", "D107", "D417"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.ruff.lint.pydoclint]
+ignore-one-line-docstrings = true
 
 [tool.pytest.ini_options]
 testpaths = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,7 @@ target-version = "py310"
 preview = true
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "D", "DOC"]
-extend-select = ["D101", "D102", "D103", "D107", "D417"]
+select = ["E", "W", "F", "I", "D", "DOC", "N", "UP", "B"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/lambkin/common/exceptions.py
+++ b/src/lambkin/common/exceptions.py
@@ -35,22 +35,16 @@ class LambkinProcessDiedUnexpectedlyError(LambkinError):
     """Raised when a background process exits before the context manager does.
 
     Attributes:
-    ----------
-    argv : list[str]
-        The command that died.
-    returncode : int
-        The exit code of the process.
+        argv (list[str]): The command that died.
+        returncode (int): The exit code of the process.
     """
 
     def __init__(self, argv: list[str], returncode: int) -> None:
         """Initialize with the command and its exit code.
 
-        Parameters
-        ----------
-        argv : list[str]
-            The command that died.
-        returncode : int
-            The exit code of the process.
+        Args:
+            argv (list[str]): The command that died.
+            returncode (int): The exit code of the process.
         """
         self.argv = argv
         self.returncode = returncode

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -58,9 +58,9 @@ class OutputInfo:
         Args:
             base_dir (Path): Base output folder for benchmark.(e.g. results/).
             variant_dir (Path): Root output folder for this variant
-                (e.g.results/var_1/).
+                (e.g. results/var_1/).
             iteration_dir (Path): Output folder for the
-                current iteration (e.g.results/var_1/iter_1/).
+                current iteration (e.g. results/var_1/iter_1/).
         """
         self.variant_dir = Path(variant_dir)
         self.base_dir = Path(base_dir)
@@ -116,28 +116,24 @@ class Context:
         access.
 
         Args:
-            variant (dict): Algorithm parameters for this run, as defined by the
-            user.
-                All key-value pairs are exposed as attributes on
-                ''ctx.variant''.
+            variant (dict): Algorithm parameters for this run, as defined by the user.
+                All key-value pairs are exposed as attributes on ``ctx.variant``.
             iteration (int): Zero-based repetition index within this variant.
-                Controls the ''iter_<N>'' subfolder name under the variant
-                directory, where ''N = iteration + 1''.
+                Controls the ``iter_<N>`` subfolder name under the variant
+                directory, where ``N = iteration + 1``.
             source (Source): Source object describing the benchmark script being
                 executed. Its parent directory is used as the default output
                 directory.
             options (dict): Runtime options, as defined by the user.
-                All key-value pairs are exposed as attributes on
-                ''ctx.options''.
+                All key-value pairs are exposed as attributes on ``ctx.options``.
             inputs (SimpleNamespace | None): Namespaced input information.
                 Defaults to None.
             variant_index (int): Zero-based index of this variant within the
-                benchmark sweep.
-                Controls the ''var_<N>'' subfolder name under the output
-                directory, where ''N = variant_index + 1''. Defaults to 0.
+                benchmark sweep. Controls the ``var_<N>`` subfolder name under
+                the output directory, where ``N = variant_index + 1``.
+                Defaults to 0.
             output_dir (Path | str | None): Root directory for all benchmark
-            results.
-                If not provided, defaults to ''source.path.parent''.
+                results. If not provided, defaults to ``source.path.parent``.
         """
         # ctx.variant
         object.__setattr__(self, "variant", SimpleNamespace(**variant))

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -47,29 +47,23 @@ class OutputInfo:
     Folders are created lazily — only when the path is first accessed.
 
     Attributes:
-    ----------
-    base_dir :
-        Base output folder for benchmark.(e.g. results/).
-    variant_dir:
-        Root folder for this variant (e.g.
-        results/var_1/).
-    iteration_dir:
-        Folder for the current iteration (e.g. results/var_1/iter_1/).
+        base_dir: Base output folder for the benchmark (e.g. results/).
+        variant_dir: Root folder for this variant (e.g. results/var_1/).
+        iteration_dir: Folder for the current iteration (e.g. results/var_1/iter_1/).
     """
 
     def __init__(self, base_dir: Path, variant_dir: Path, iteration_dir: Path) -> None:
         """Initialize the output paths for one (variant, iteration) pair.
 
-        Parameters
-        ----------
-        base_dir : Path
-            Base output folder for benchmark.(e.g. results/).
-        variant_dir : Path
-            Root output folder for this variant
-            (e.g. results/var_1/).
-        iteration_dir : Path
-            Output folder for the current iteration (e.g.
-            results/var_1/iter_1/).
+        Args:
+            base_dir : Path
+                Base output folder for benchmark.(e.g. results/).
+            variant_dir : Path
+                Root output folder for this variant
+                (e.g. results/var_1/).
+            iteration_dir : Path
+                Output folder for the current iteration (e.g.
+                results/var_1/iter_1/).
         """
         self.variant_dir = Path(variant_dir)
         self.base_dir = Path(base_dir)
@@ -95,21 +89,20 @@ class Context:
     folders on disk.
 
     Attributes:
-    ----------
-    BENCHMARKS_DIRNAME : str
-        Name for the benchmarks directory.
-    variation:
-        Namespaced algorithm parameters for this run.
-        All key-value pairs from the variant dict are exposed as attributes.
-    source:
-        Source object describing the benchmark script being executed.
-    inputs:
-        Namespaced input information.
-    options:
-        Namespaced runtime options.
-        All key-value pairs from the options dict are exposed as attributes.
-    output:
-        Namespaced output paths.
+        BENCHMARKS_DIRNAME : str
+            Name for the benchmarks directory.
+        variation:
+            Namespaced algorithm parameters for this run.
+            All key-value pairs from the variant dict are exposed as attributes.
+        source:
+            Source object describing the benchmark script being executed.
+        inputs:
+            Namespaced input information.
+        options:
+            Namespaced runtime options.
+            All key-value pairs from the options dict are exposed as attributes.
+        output:
+            Namespaced output paths.
     """
 
     BENCHMARKS_DIRNAME = "results"
@@ -130,28 +123,29 @@ class Context:
         stored at construction time. Output subfolders for variant and iteration
         are created immediately, while any other subfolder is created on first access.
 
-        Parameters
-        ----------
-        variant : dict
-            Algorithm parameters for this run, as defined by the user.
-            All key-value pairs are exposed as attributes on "ctx.variant".
-        iteration : int
-            Zero-based repetition index within this variant.
-            Controls the "iter_<N>" subfolder name under the variant directory.
-            where "N = iteration + 1".
-        source : Source
-            Source object describing the benchmark script being executed.
-            Its parent directory is used as the default output directory.
-        options : dict
-            Runtime options, as defined by the user.
-            All key-value pairs are exposed as attributes on "ctx.options".
-        variant_index : int, optional
-            Zero-based index of this variant within the benchmark sweep.
-            Controls the "var_<N>" subfolder name under the output directory,
-            where "N = variant_index + 1". Defaults to 0.
-        output_dir : Path or str, optional
-            Root directory for all benchmark results. If not provided,
-            defaults to "source.path.parent".
+        Args:
+            variant : dict
+                Algorithm parameters for this run, as defined by the user.
+                All key-value pairs are exposed as attributes on "ctx.variant".
+            iteration : int
+                Zero-based repetition index within this variant.
+                Controls the "iter_<N>" subfolder name under the variant directory.
+                where "N = iteration + 1".
+            source : Source
+                Source object describing the benchmark script being executed.
+                Its parent directory is used as the default output directory.
+            options : dict
+                Runtime options, as defined by the user.
+                All key-value pairs are exposed as attributes on "ctx.options".
+            inputs: SimpleNamespace
+                Namespaced input information. Defaults to None.
+            variant_index : int, optional
+                Zero-based index of this variant within the benchmark sweep.
+                Controls the "var_<N>" subfolder name under the output directory,
+                where "N = variant_index + 1". Defaults to 0.
+            output_dir : Path or str, optional
+                Root directory for all benchmark results. If not provided,
+                defaults to "source.path.parent".
         """
         # ctx.variant
         object.__setattr__(self, "variant", SimpleNamespace(**variant))

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -56,14 +56,11 @@ class OutputInfo:
         """Initialize the output paths for one (variant, iteration) pair.
 
         Args:
-            base_dir : Path
-                Base output folder for benchmark.(e.g. results/).
-            variant_dir : Path
-                Root output folder for this variant
-                (e.g. results/var_1/).
-            iteration_dir : Path
-                Output folder for the current iteration (e.g.
-                results/var_1/iter_1/).
+            base_dir (Path): Base output folder for benchmark.(e.g. results/).
+            variant_dir (Path): Root output folder for this variant
+                (e.g.results/var_1/).
+            iteration_dir (Path): Output folder for the
+                current iteration (e.g.results/var_1/iter_1/).
         """
         self.variant_dir = Path(variant_dir)
         self.base_dir = Path(base_dir)
@@ -89,20 +86,14 @@ class Context:
     folders on disk.
 
     Attributes:
-        BENCHMARKS_DIRNAME : str
-            Name for the benchmarks directory.
-        variation:
-            Namespaced algorithm parameters for this run.
+        BENCHMARKS_DIRNAME (str): Name for the benchmarks directory.
+        variation: Namespaced algorithm parameters for this run.
             All key-value pairs from the variant dict are exposed as attributes.
-        source:
-            Source object describing the benchmark script being executed.
-        inputs:
-            Namespaced input information.
-        options:
-            Namespaced runtime options.
+        source: Source object describing the benchmark script being executed.
+        inputs: Namespaced input information.
+        options: Namespaced runtime options.
             All key-value pairs from the options dict are exposed as attributes.
-        output:
-            Namespaced output paths.
+        output: Namespaced output paths.
     """
 
     BENCHMARKS_DIRNAME = "results"
@@ -121,31 +112,32 @@ class Context:
 
         Only the parameters needed to build the namespaced sub-objects are
         stored at construction time. Output subfolders for variant and iteration
-        are created immediately, while any other subfolder is created on first access.
+        are created immediately, while any other subfolder is created on first
+        access.
 
         Args:
-            variant : dict
-                Algorithm parameters for this run, as defined by the user.
-                All key-value pairs are exposed as attributes on "ctx.variant".
-            iteration : int
-                Zero-based repetition index within this variant.
-                Controls the "iter_<N>" subfolder name under the variant directory.
-                where "N = iteration + 1".
-            source : Source
-                Source object describing the benchmark script being executed.
-                Its parent directory is used as the default output directory.
-            options : dict
-                Runtime options, as defined by the user.
-                All key-value pairs are exposed as attributes on "ctx.options".
-            inputs: SimpleNamespace
-                Namespaced input information. Defaults to None.
-            variant_index : int, optional
-                Zero-based index of this variant within the benchmark sweep.
-                Controls the "var_<N>" subfolder name under the output directory,
-                where "N = variant_index + 1". Defaults to 0.
-            output_dir : Path or str, optional
-                Root directory for all benchmark results. If not provided,
-                defaults to "source.path.parent".
+            variant (dict): Algorithm parameters for this run, as defined by the
+            user.
+                All key-value pairs are exposed as attributes on
+                ''ctx.variant''.
+            iteration (int): Zero-based repetition index within this variant.
+                Controls the ''iter_<N>'' subfolder name under the variant
+                directory, where ''N = iteration + 1''.
+            source (Source): Source object describing the benchmark script being
+                executed. Its parent directory is used as the default output
+                directory.
+            options (dict): Runtime options, as defined by the user.
+                All key-value pairs are exposed as attributes on
+                ''ctx.options''.
+            inputs (SimpleNamespace | None): Namespaced input information.
+                Defaults to None.
+            variant_index (int): Zero-based index of this variant within the
+                benchmark sweep.
+                Controls the ''var_<N>'' subfolder name under the output
+                directory, where ''N = variant_index + 1''. Defaults to 0.
+            output_dir (Path | str | None): Root directory for all benchmark
+            results.
+                If not provided, defaults to ''source.path.parent''.
         """
         # ctx.variant
         object.__setattr__(self, "variant", SimpleNamespace(**variant))
@@ -214,7 +206,7 @@ class Context:
         """Write a YAML metadata file to the iteration output directory.
 
         Serializes run identity, parameters, source, and output paths
-        to 'metadata.yaml inside 'output.iteration_dir'. The file
+        to ''metadata.yaml'' inside ''output.iteration_dir''. The file
         is written once at context creation time and is not updated afterwards.
         """
         metadata = {

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -202,7 +202,7 @@ class Context:
         """Write a YAML metadata file to the iteration output directory.
 
         Serializes run identity, parameters, source, and output paths
-        to ''metadata.yaml'' inside ''output.iteration_dir''. The file
+        to ``metadata.yaml`` inside ``output.iteration_dir``. The file
         is written once at context creation time and is not updated afterwards.
         """
         metadata = {

--- a/src/lambkin/core/ctx/source.py
+++ b/src/lambkin/core/ctx/source.py
@@ -25,18 +25,14 @@ class Source:
     """Describes the benchmark source file.
 
     Attributes:
-    ----------
-    path:
-        Path to the source file of the benchmark.
+        path: Path to the source file of the benchmark.
     """
 
     def __init__(self, path: Path | str) -> None:
         """Initialize a Source with the path to the benchmark script.
 
-        Parameters
-        ----------
-        path : Path or str
-            Path to the source file of the benchmark.
+        Args:
+            path: Path to the source file of the benchmark.
         """
         self.path = Path(path)
 

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -88,19 +88,16 @@ def benchmark(variants, num_iterations):
     function with it. Input hooks registered via @nominal.input are resolved
     before each call, injecting their return values into ctx.inputs.
 
-    Parameters
-    ----------
-    variants : iterable of dict
-        Sequence of variant dicts to sweep over. Each dict is exposed as
-        attributes on ctx.variant.
-    num_iterations : int
-        Number of times to repeat each variant. Controls the iter_<N> subfolders
-        under each variant directory.
+    Args:
+        variants : iterable of dict
+            Sequence of variant dicts to sweep over. Each dict is exposed as
+            attributes on ctx.variant.
+        num_iterations : int
+            Number of times to repeat each variant. Controls the iter_<N> subfolders
+            under each variant directory.
 
     Raises:
-    ------
-    ValueError
-        If variants is empty
+        ValueError: If variants is empty
     """
     if not variants:
         raise ValueError(

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -14,7 +14,7 @@
 
 """Benchmark loop decorator for lambkin.
 
-Provides the @benchmark decorator, which drives the execution loopover all
+Provides the @benchmark decorator,which drives the execution loop over all
 variants and iterations. It collects CLI option definitions registered by
 @option, parses them once before the loop using an internal click parser, and
 injects the resulting values into a Context class on each (variant, iteration)
@@ -89,12 +89,10 @@ def benchmark(variants, num_iterations):
     before each call, injecting their return values into ctx.inputs.
 
     Args:
-        variants : iterable of dict
-            Sequence of variant dicts to sweep over. Each dict is exposed as
-            attributes on ctx.variant.
-        num_iterations : int
-            Number of times to repeat each variant. Controls the iter_<N> subfolders
-            under each variant directory.
+        variants (list[dict]): Sequence of variant dicts to sweep over. Each dict
+            is exposed as attributes on ''ctx.variant''.
+        num_iterations (int): Number of times to repeat each variant. Controls the
+            ''iter_<N>'' subfolders under each variant directory.
 
     Raises:
         ValueError: If variants is empty

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -52,20 +52,16 @@ def _show_options(fn) -> None:
         if not user_options:
             formatter.write_text("No options registered in this script.")
         else:
-            formatter.write_dl(
-                [
-                    (
-                        opt.opts[0],
-                        (opt.help or "")
-                        + (
-                            f"  [default: {opt.default}]"
-                            if opt.default is not None
-                            else ""
-                        ),
-                    )
-                    for opt in user_options
-                ]
-            )
+            formatter.write_dl([
+                (
+                    opt.opts[0],
+                    (opt.help or "")
+                    + (
+                        f"  [default: {opt.default}]" if opt.default is not None else ""
+                    ),
+                )
+                for opt in user_options
+            ])
     click.echo(formatter.getvalue(), nl=False)
 
 
@@ -93,6 +89,9 @@ def benchmark(variants, num_iterations):
            is exposed as attributes on ``ctx.variant``.
         num_iterations (int): Number of times to repeat each variant. Controls the
             ``iter_<N>`` subfolders under each variant directory.
+
+    Returns:
+        A decorator that wraps the benchmark function with the execution loop.
 
     Raises:
         ValueError: If variants is empty

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -14,7 +14,7 @@
 
 """Benchmark loop decorator for lambkin.
 
-Provides the @benchmark decorator,which drives the execution loop over all
+Provides the @benchmark decorator, which drives the execution loop over all
 variants and iterations. It collects CLI option definitions registered by
 @option, parses them once before the loop using an internal click parser, and
 injects the resulting values into a Context class on each (variant, iteration)
@@ -90,9 +90,9 @@ def benchmark(variants, num_iterations):
 
     Args:
         variants (list[dict]): Sequence of variant dicts to sweep over. Each dict
-            is exposed as attributes on ''ctx.variant''.
+           is exposed as attributes on ``ctx.variant``.
         num_iterations (int): Number of times to repeat each variant. Controls the
-            ''iter_<N>'' subfolders under each variant directory.
+            ``iter_<N>`` subfolders under each variant directory.
 
     Raises:
         ValueError: If variants is empty

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -65,6 +65,16 @@ class InputRegistry:
             Do not access ``ctx.variant`` or ``ctx.iteration`` inside the hook;
             they will contain dummy values at resolve time, leading to silent
             bugs that are hard to trace.
+
+        Args:
+            hook_fn: The function to register as an input provider.
+
+        Returns:
+            The hook function, unchanged.
+
+        Raises:
+            ValueError: If the hook signature is invalid or its name is already
+                registered.
         """
         _validate_hook_signature(hook_fn)
         existing_names = [h.__name__ for h in self._hooks]
@@ -81,6 +91,10 @@ class InputRegistry:
         Collects all hook results into a local dict first so ctx is never
         mutated during resolution. The returned snapshot is passed to the
         Context constructor by the benchmark runner.
+
+        Returns:
+            SimpleNamespace: A snapshot mapping each hook's function name to
+                its return value.
         """
         resolved = {}
         for hook in self._hooks:

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -49,9 +49,9 @@ class InputRegistry:
 
     Warning:
        Hooks are resolved with a base context containing dummy variant and
-       iteration values. Accessing ctx.variant or ctx.iteration inside a hook
-       will silently return empty/wrong values. Hooks should only depend on
-       ctx.options or other stable context fields.
+        iteration values. Accessing ``ctx.variant`` or ``ctx.iteration`` inside
+        a hook will silently return empty/wrong values. Hooks should only depend
+        on ``ctx.options`` or other stable context fields.
     """
 
     def __init__(self):
@@ -61,9 +61,10 @@ class InputRegistry:
     def register(self, hook_fn):
         """Decorator used to register a function as an input provider.
 
-        Warning: Do not access ctx.variant or ctx.iteration inside the hook,
-        they will contain dummy values at resolve time, leading to silent bugs
-        that are hard to trace.
+        Warning:
+            Do not access ``ctx.variant`` or ``ctx.iteration`` inside the hook;
+            they will contain dummy values at resolve time, leading to silent
+            bugs that are hard to trace.
         """
         _validate_hook_signature(hook_fn)
         existing_names = [h.__name__ for h in self._hooks]

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -48,10 +48,10 @@ class InputRegistry:
     """Manages the registration and resolution of input hooks for a benchmark.
 
     Warning:
-       Hooks are resolved with a base context containing dummy variant and
-        iteration values. Accessing ``ctx.variant`` or ``ctx.iteration`` inside
+        Hooks are resolved with a base context containing dummy variant and
+        iteration values. Accessing ''ctx.variant'' or ''ctx.iteration'' inside
         a hook will silently return empty/wrong values. Hooks should only depend
-        on ``ctx.options`` or other stable context fields.
+        on ''ctx.options'' or other stable context fields.
     """
 
     def __init__(self):
@@ -62,7 +62,7 @@ class InputRegistry:
         """Decorator used to register a function as an input provider.
 
         Warning:
-            Do not access ``ctx.variant`` or ``ctx.iteration`` inside the hook;
+            Do not access ''ctx.variant'' or ''ctx.iteration'' inside the hook;
             they will contain dummy values at resolve time, leading to silent
             bugs that are hard to trace.
         """

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -49,9 +49,9 @@ class InputRegistry:
 
     Warning:
         Hooks are resolved with a base context containing dummy variant and
-        iteration values. Accessing ''ctx.variant'' or ''ctx.iteration'' inside
-        a hook will silently return empty/wrong values. Hooks should only depend
-        on ''ctx.options'' or other stable context fields.
+        iteration values. Accessing Accessing ``ctx.variant`` or
+        ``ctx.iteration`` inside a hook will silently return empty/wrong values.
+        Hooks should only depend on ``ctx.options`` or other stable context fields.
     """
 
     def __init__(self):
@@ -62,7 +62,7 @@ class InputRegistry:
         """Decorator used to register a function as an input provider.
 
         Warning:
-            Do not access ''ctx.variant'' or ''ctx.iteration'' inside the hook;
+            Do not access ``ctx.variant`` or ``ctx.iteration`` inside the hook;
             they will contain dummy values at resolve time, leading to silent
             bugs that are hard to trace.
         """

--- a/src/lambkin/core/decorators/option.py
+++ b/src/lambkin/core/decorators/option.py
@@ -28,6 +28,12 @@ from click import Option
 def option(*param_decls, **attrs):
     """Registers a CLI option on the benchmark function.
 
+    Returns:
+        A decorator that attaches the option to the benchmark function.
+
+    Raises:
+        ValueError: If any flag name does not start with '-' or '--'.
+
     Example:
         @lambkin.option("--clock-rate", default=100.0)
         @lambkin.option("--sensor-topic", default="/scan")

--- a/src/lambkin/core/process/background.py
+++ b/src/lambkin/core/process/background.py
@@ -59,22 +59,16 @@ class BackgroundProcess:
     ) -> None:
         """Initialize the BackgroundProcess.
 
-        Parameters
-        ----------
-        argv : list[str]
-            The command to run as a list of tokens.
-        iteration_cgroup : Path
-            The cgroup directory for this iteration.
-        dry_run : bool
-            If True, log the command instead of executing it.
-        cwd : Path, optional
-            Working directory for the process. If None, inherits from the parent.
-        env : dict, optional
-            Environment variables for the process. If None, inherits from the parent.
-        stdout : file, optional
-            stdout stream for the process. If None, inherits from the parent.
-        stderr : file, optional
-            stderr stream for the process. If None, inherits from the parent.
+        Args:
+            argv (list[str]): The command to run as a list of tokens.
+            iteration_cgroup (Path): The cgroup directory for this iteration.
+            cwd (Path | None): Working directory for the process. If None,
+                inherits from the parent.
+            dry_run (bool): If True, log the command instead of executing it.
+            env (dict | None): Environment variables for the process. If None,
+                inherits from the parent.
+            stdout: stdout stream for the process. If None, inherits from the parent.
+            stderr: stderr stream for the process. If None, inherits from the parent.
         """
         self._argv = argv
         self._iteration_cgroup = iteration_cgroup

--- a/src/lambkin/core/process/background.py
+++ b/src/lambkin/core/process/background.py
@@ -108,9 +108,7 @@ class BackgroundProcess:
         In dry-run mode, logs the command at debug level instead of executing it.
 
         Returns:
-        -------
-        BackgroundProcess
-            This instance.
+            BackgroundProcess: This instance.
         """
         if self._dry_run:
             logger.info("[DRY RUN BG] %s", shlex.join(self._argv))
@@ -136,20 +134,14 @@ class BackgroundProcess:
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """Stop the background process and clean up its cgroup.
 
-        Parameters
-        ----------
-        exc_type :
-            Exception type if an exception is propagating, else None.
-        exc_val :
-            Exception value if an exception is propagating, else None.
-        exc_tb :
-            Exception traceback if an exception is propagating, else None.
+        Args:
+            exc_type: Exception type if an exception is propagating, else None.
+            exc_val: Exception value if an exception is propagating, else None.
+            exc_tb: Exception traceback if an exception is propagating, else None.
 
         Raises:
-        ------
-        LambkinProcessDiedUnexpectedlyError
-            If the process died before this method was called and no other
-            exception is already propagating.
+            LambkinProcessDiedUnexpectedlyError: If the process died before this
+                method was called and no other exception is already propagating.
         """
         if self._dry_run:
             return
@@ -176,29 +168,16 @@ class BackgroundProcess:
 def background(proxy: CommandProxy, *args: Any, **kwargs: Any) -> BackgroundProcess:
     """Create a BackgroundProcess context manager from a command proxy.
 
-    Intercepts the ``log_output`` keyword argument if present and uses it
-    to open stdout and stderr log files via the proxy before the process
-    starts. The resolved output mode follows the same precedence as foreground
-    commands: CLI flag overrides per-call kwarg, which overrides the default.
-
-    Parameters
-    ----------
-    proxy : CommandProxy
-        A command proxy representing the command to run.
-    *args :
-        Positional arguments to append to the command.
-    **kwargs :
-        Keyword arguments to convert to --flag value pairs. ``log_output``
-        is intercepted and never forwarded to the subprocess.
+    Args:
+        proxy (CommandProxy): A command proxy representing the command to run.
+        *args: Positional arguments to append to the command.
+        **kwargs: Keyword arguments to convert to --flag value pairs.
 
     Returns:
-    -------
-    BackgroundProcess
-        A context manager that runs the command in the background.
+        BackgroundProcess: A context manager that runs the command in the background.
 
     Example:
-    -------
-    with background(ctx.shell.ros2.bag.record, "-O", "output.mcap", "-a"):
+        with background(ctx.shell.ros2.bag.record, "-O", "output.mcap", "-a"):
         ...
     """
     per_call_log_output = kwargs.pop("log_output", None)

--- a/src/lambkin/core/process/cgroup.py
+++ b/src/lambkin/core/process/cgroup.py
@@ -142,7 +142,10 @@ def remove_cgroup(cgroup: Path) -> None:
     """Remove a cgroup directory once it is empty.
 
     Args:
-       cgroup (Path): The cgroup directory to remove.
+        cgroup (Path): The cgroup directory to remove.
+
+    Raises:
+        OSError: If an unexpected OS error occurs while removing the directory.
     """
     deadline = time.monotonic() + defaults.SIGKILL_GRACE_PERIOD
     while time.monotonic() < deadline:

--- a/src/lambkin/core/process/cgroup.py
+++ b/src/lambkin/core/process/cgroup.py
@@ -32,14 +32,10 @@ def find_delegated_cgroup() -> Path:
     """Return the delegated cgroup for the current process.
 
     Returns:
-    -------
-    Path
-        The cgroup directory for the current process.
+        Path: The cgroup directory for the current process.
 
     Raises:
-    ------
-    RuntimeError
-        If no cgroup v2 directory is found.
+        RuntimeError: If no cgroup v2 directory is found.
     """
     cgroup_file = Path("/proc/self/cgroup")
     for line in cgroup_file.read_text().splitlines():
@@ -69,9 +65,8 @@ def find_app_slice() -> Path | None:
     """Return the user app.slice cgroup if writable, else None.
 
     Returns:
-    -------
-    Path or None
-        The app.slice cgroup path if it exists and is writable, else None.
+        Path | None: The app.slice cgroup path if it exists and is writable,
+            else None.
     """
     uid = os.getuid()
     app_slice = Path(
@@ -85,17 +80,12 @@ def find_app_slice() -> Path | None:
 def make_cgroup(parent: Path, name: str) -> Path:
     """Create a child cgroup under parent and return its path.
 
-    Parameters
-    ----------
-    parent : Path
-        The parent cgroup directory.
-    name : str
-        Name for the new child cgroup.
+    Args:
+        parent (Path): The parent cgroup directory.
+        name (str): Name for the new child cgroup.
 
     Returns:
-    -------
-    Path
-        The path to the newly created cgroup directory.
+        Path: The path to the newly created cgroup directory.
     """
     child = parent / name
     child.mkdir(exist_ok=True)
@@ -108,12 +98,9 @@ def kill_cgroup(cgroup: Path, grace_period: float = 3.0) -> None:
     Sends SIGTERM to all members first, waits for the grace period, then
     sends SIGKILL to any survivors.
 
-    Parameters
-    ----------
-    cgroup : Path
-        The cgroup directory to kill.
-    grace_period : float
-        Seconds to wait after SIGTERM before sending SIGKILL.
+    Args:
+        cgroup (Path): The cgroup directory to kill.
+        grace_period (float): Seconds to wait after SIGTERM before sending SIGKILL.
     """
     procs_file = cgroup / "cgroup.procs"
 
@@ -154,10 +141,8 @@ def kill_cgroup(cgroup: Path, grace_period: float = 3.0) -> None:
 def remove_cgroup(cgroup: Path) -> None:
     """Remove a cgroup directory once it is empty.
 
-    Parameters
-    ----------
-    cgroup : Path
-        The cgroup directory to remove.
+    Args:
+       cgroup (Path): The cgroup directory to remove.
     """
     deadline = time.monotonic() + defaults.SIGKILL_GRACE_PERIOD
     while time.monotonic() < deadline:
@@ -186,10 +171,8 @@ def kill_cgroup_tree(cgroup: Path, grace_period: float = 3.0) -> None:
     waits for all threads to exit.
 
     Args:
-        cgroup : Path
-            The root cgroup directory to kill.
-        grace_period : float
-            Seconds to wait for all processes to die after SIGKILL.
+        cgroup (Path): The root cgroup directory to kill.
+        grace_period (float): Seconds to wait for all processes to die after SIGKILL.
     """
     (cgroup / "cgroup.kill").write_text("1")
     deadline = time.monotonic() + grace_period
@@ -206,8 +189,7 @@ def remove_cgroup_tree(cgroup: Path) -> None:
     Does not kill processes — call ``kill_cgroup_tree`` first if needed.
 
     Args:
-        cgroup : Path
-            The root cgroup directory to remove.
+        cgroup (Path): The root cgroup directory to remove.
     """
     for child in sorted(cgroup.iterdir(), reverse=True):
         if child.is_dir():
@@ -218,17 +200,13 @@ def remove_cgroup_tree(cgroup: Path) -> None:
 def make_iteration_cgroup(delegated: Path, iteration_dir: Path) -> Path:
     """Create a cgroup for one benchmark iteration.
 
-    Parameters
-    ----------
-    delegated : Path
-        The delegated cgroup for this process.
-    iteration_dir : Path
-        The iteration output directory, used to derive a unique cgroup name.
+    Args:
+        delegated (Path): The delegated cgroup for this process.
+        iteration_dir (Path): The iteration output directory, used to derive
+            a unique cgroup name.
 
     Returns:
-    -------
-    Path
-        The path to the newly created iteration cgroup directory.
+        Path: The path to the newly created iteration cgroup directory.
     """
     name = (
         f"iter-{iteration_dir.parent.name}-{iteration_dir.name}-{uuid.uuid4().hex[:8]}"
@@ -239,17 +217,13 @@ def make_iteration_cgroup(delegated: Path, iteration_dir: Path) -> Path:
 def make_process_cgroup(parent: Path, argv: list[str]) -> Path:
     """Create a cgroup for a background process.
 
-    Parameters
-    ----------
-    parent : Path
-        The parent cgroup directory (typically the iteration cgroup).
-    argv : list[str]
-        The command argv, used to derive a human-readable cgroup name.
+    Args:
+        parent (Path): The parent cgroup directory (typically the iteration cgroup).
+        argv (list[str]): The command argv, used to derive a human-readable
+            cgroup name.
 
     Returns:
-    -------
-    Path
-        The path to the newly created cgroup directory.
+        Path: The path to the newly created cgroup directory.
     """
     name = f"{argv[0].split('/')[-1]}-{uuid.uuid4().hex[:8]}"
     return make_cgroup(parent, name)

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -84,16 +84,16 @@ class CommandProxy:
         """Initialize the proxy with the command tokens accumulated so far.
 
         Args:
-        parts: The list of command tokens accumulated so far.
-        dry_run: If True, commands are logged instead of executed.
-        cwd: Working directory for the command when dispatched.
-        cgroup: Iteration cgroup directory for background processes.
-        benchmark_log_output: Log output mode set via CLI. Overrides any
-        per-call log_output argument. None means no CLI override was
-        provided.
-        call_counts: Shared dictionary tracking how many times each command
-        has been launched in the current iteration, used to append
-        numeric suffixes to log file names to avoid collisions.
+            parts: The list of command tokens accumulated so far.
+            dry_run: If True, commands are logged instead of executed.
+            cwd: Working directory for the command when dispatched.
+            cgroup: Iteration cgroup directory for background processes.
+            benchmark_log_output: Log output mode set via CLI. Overrides any
+            per-call log_output argument. None means no CLI override was
+            provided.
+            call_counts: Shared dictionary tracking how many times each command
+            has been launched in the current iteration, used to append
+            numeric suffixes to log file names to avoid collisions.
         """
         self._parts = parts
         self._dry_run = dry_run

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -89,11 +89,11 @@ class CommandProxy:
             cwd: Working directory for the command when dispatched.
             cgroup: Iteration cgroup directory for background processes.
             benchmark_log_output: Log output mode set via CLI. Overrides any
-            per-call log_output argument. None means no CLI override was
-            provided.
+                per-call log_output argument. None means no CLI override was
+                provided.
             call_counts: Shared dictionary tracking how many times each command
-            has been launched in the current iteration, used to append
-            numeric suffixes to log file names to avoid collisions.
+                has been launched in the current iteration, used to append
+                numeric suffixes to log file names to avoid collisions.
         """
         self._parts = parts
         self._dry_run = dry_run
@@ -290,7 +290,10 @@ class CommandProxy:
             dummy CompletedProcess(argv, returncode=0) in dry-run mode.
 
         Raises:
-            CommandError: If the process exits with a non-zero return code.
+            CommandError: If the process exits with a non-zero return code,
+                or if the executable is not found or not executable.
+            subprocess.CalledProcessError: Internal — caught and re-raised as
+                ``CommandError``. Never propagates to the caller.
         """
         per_call_log_output = kwargs.pop("log_output", None)
         argv = self.build_argv(*args, **kwargs)
@@ -367,7 +370,7 @@ class ShellProxy:
             cwd: Working directory for all commands dispatched through this proxy.
             cgroup: Iteration cgroup directory for background processes.
             log_output: Log output mode set via CLI. Overrides any per-call
-            log_output argument. None means no CLI override was provided.
+                log_output argument. None means no CLI override was provided.
         """
         self._dry_run = dry_run
         self._cwd = cwd

--- a/test/integration/integration_test_foreground_fails.py
+++ b/test/integration/integration_test_foreground_fails.py
@@ -40,6 +40,9 @@ def main():
 
     Verifies that when the foreground raises an exception, both background
     processes are terminated cleanly and the original exception is propagated.
+
+    Raises:
+        RuntimeError: Intentionally raised to simulate a foreground failure.
     """
     iteration_dir = Path(tempfile.mkdtemp())
     try:


### PR DESCRIPTION
### Proposed changes

All docstrings across the SDK now follow Google style consistently.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Additional comments

N/A