### PR TITLE
Phase 4: Rename metadata file to lambkin_metadata

### DIFF
--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -218,7 +218,7 @@ class Context:
                 "iteration_dir": str(self.output.iteration_dir),
             },
         }
-        meta_path = self.output.iteration_dir / "metadata.yaml"
+        meta_path = self.output.iteration_dir / "lambkin_metadata.yaml"
         with open(meta_path, "w") as f:
             yaml.dump(metadata, f, default_flow_style=False, sort_keys=False)
 


### PR DESCRIPTION
### Proposed changes

Rename `metadata.yaml` to `lambkin_metadata.yaml` to avoid overwriting the metadata file generated by `ros2 bag record`, which uses the same filename inside the output directory.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments

N/A
