### PR TITLE
Phase 5: Add variants file and useful logs

### DIFF
--- a/examples/beluga/beluga_benchmark.py
+++ b/examples/beluga/beluga_benchmark.py
@@ -33,7 +33,10 @@ def nominal(ctx):
     Args:
         ctx: Lambkin context with variant, options, source, and shell access.
     """
-    lambkin.logger.info("Running benchmark with variant: %s", ctx.variant)
+    lambkin.logger.info(
+        "Running benchmark with variant: %s, iteration: %d", ctx.variant, ctx.iteration
+    )
+
     with lambkin.process.background(
         ctx.shell.ros2.bag.record,
         "--output",

--- a/src/lambkin/README.md
+++ b/src/lambkin/README.md
@@ -56,6 +56,7 @@ Runs a process in the background while the benchmark continues executing. Takes 
 LAMBKIN places each iteration in its own cgroup, so every process spawned during that run — whether inside a background() block or not — is tracked and torn down unconditionally when the iteration ends. This means no leftover processes survive into the next iteration, and no process can escape by calling `setsid` or `setpgid` — the kernel enforces containment regardless.
 
 The cgroup hierarchy for a run looks like this:
+
 ```
 app.slice/                               ← user's systemd app slice
 └── lambkin-my_benchmark-a1b2c3d4/       ← one per CLI invocation
@@ -63,6 +64,7 @@ app.slice/                               ← user's systemd app slice
         ├── my_algorithm-a9b0c1d2/       ← ros2 launch process
         └── my_recorder-e3f4a5b6/        ← ros2 bag record process
 ```
+
 When running on the host, a user systemd app slice (app.slice) is always available. In containerized environments no app slice may exist — in that case, LAMBKIN falls back to the nearest delegated cgroup it can find. For example, under Podman with `--systemd=always`:
 ```
 user.slice/user-1000.slice/user@1000.service/  ← delegated cgroup root
@@ -78,7 +80,6 @@ user.slice/user-1000.slice/user@1000.service/  ← delegated cgroup root
 ### Process Cleanup
 
 When an iteration completes, LAMBKIN tears down the iteration cgroup by sending `SIGTERM` to all remaining processes, waiting for a grace period, then sending `SIGKILL` to any survivors. On Ctrl-C, the CLI writes 1 to `cgroup.kill`, which the kernel propagates instantly to the entire iteration cgroup.
-
 
 ## CLI
 
@@ -114,6 +115,7 @@ LAMBKIN has two independent logging systems: one for its own internal messages a
 ### SDK Logging
 
 Controls the verbosity of LAMBKIN's own internal messages via the `--log-level` SDK option. Accepts any level supported by [Python's logging](https://docs.python.org/3/library/logging.html#logging-levels) module, case-insensitive:
+
 ```bash
 lambkin my_benchmark.py --log-level debug
 lambkin my_benchmark.py --log-level DEBUG  # equivalent
@@ -124,6 +126,7 @@ The LAMBKIN logger is fully isolated from the root logger — user scripts can c
 ### Process Logging
 
 Controls where subprocess stdout and stderr are routed. Each process can be configured independently via log_output.
+
 ```bash
 lambkin my_benchmark.py --log-output console
 ```
@@ -134,7 +137,8 @@ lambkin my_benchmark.py --log-output console
 | `"file"` | Writes subprocess output to a per-process log file under the iteration output directory |
 
 Log files are named after the command and written to the iteration directory:
-```
+
+```bash
 results/var_1/iter_1/
 ├── my_algorithm.stdout.log
 ├── my_algorithm.stderr.log
@@ -160,7 +164,6 @@ Precedence (highest to lowest):
 git clone -b next-gen git@github.com:Ekumen-OS/lambkin.git
 uv sync
 ```
-
 
 ## Usage
 
@@ -197,6 +200,7 @@ def dataset(ctx):
 if __name__ == "__main__":
     my_benchmark()
 ```
+
 Run it with the CLI:
 
 ```bash
@@ -204,22 +208,26 @@ lambkin my_benchmark.py --clock-rate 50.0
 ```
 
 Inspect all available options without running:
+
 ```bash
 lambkin my_benchmark.py --show-options
 ```
 
 Validate the benchmark pipeline without executing any process:
+
 ```bash
 lambkin my_benchmark.py --dry-run
 ```
-For a complete, working example using the Beluga algorithm, see [`Beluga Example`](examples/beluga/beluga_benchmark.py).
 
+For a complete, working example using the Beluga algorithm, see [`Beluga Example`](examples/beluga/beluga_benchmark.py).
 
 ## Expected Output
 
 LAMBKIN writes all artifacts under a consistent directory tree:
-```
+
+```bash
 results/
+├── variants.yaml
 └── <variant_n>/
     └── iter_<n>/
         ├── lambkin_metadata.yaml

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -31,6 +31,7 @@ import functools
 import inspect
 import logging
 import sys
+import time
 
 import click
 import yaml
@@ -44,6 +45,39 @@ from lambkin.logger import configure_logging
 from lambkin.sdk_options import SDK_OPTIONS
 
 logger = logging.getLogger(__name__)
+
+
+def _format_elapsed(seconds: float) -> str:
+    """Format an elapsed time into a human-readable string.
+
+    Scales the output unit to the duration so the result is always easy to
+    read at a glance, from sub-second runs to multi-day sweeps:
+
+    - Under 60 s:  ``'0.0023s'``
+    - Under 1 h:   ``'45m 03s'``
+    - Under 1 day: ``'2h 15m 07s'``
+    - 1 day or more: ``'2d 03h 15m 07s'``
+
+    Sub-second precision is kept only for runs under 60 seconds; longer
+    durations are truncated to whole seconds.
+
+    Args:
+        seconds: Elapsed time in seconds, as returned by ``time.monotonic()``.
+
+    Returns:
+        A human-readable elapsed time string.
+    """
+    if seconds < 60:
+        return f"{seconds:.4f}s"
+    total = int(seconds)
+    d, remainder = divmod(total, 86400)
+    h, remainder = divmod(remainder, 3600)
+    m, s = divmod(remainder, 60)
+    if d > 0:
+        return f"{d}d {h:02d}h {m:02d}m {s:02d}s"
+    if h > 0:
+        return f"{h}h {m:02d}m {s:02d}s"
+    return f"{m}m {s:02d}s"
 
 
 def _show_options(fn) -> None:
@@ -147,6 +181,9 @@ def benchmark(variants, num_iterations):
                     yaml.dump(
                         variants_map, f, default_flow_style=False, sort_keys=False
                     )
+            # Calculate start time
+            start_time = time.monotonic()
+            # Loop over variants and iterations, creating a new Context for each run.
             for variant_index, variant in enumerate(variants):
                 for iteration in range(num_iterations):
                     # Log the current run number and total runs to track progress.
@@ -162,6 +199,11 @@ def benchmark(variants, num_iterations):
                         output_dir=output_dir,
                     ) as ctx:
                         fn(ctx)
+            # Calculate total elapsed time
+            logger.info(
+                "Benchmark finished in %s.",
+                _format_elapsed(time.monotonic() - start_time),
+            )
 
         wrapper.input = inputs.register
         return wrapper

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -29,9 +29,11 @@ Raises ValueError if variants is empty.
 
 import functools
 import inspect
+import logging
 import sys
 
 import click
+import yaml
 from click.formatting import HelpFormatter
 
 from lambkin.common import defaults
@@ -40,6 +42,8 @@ from lambkin.core.ctx.source import Source
 from lambkin.core.decorators.input import InputRegistry
 from lambkin.logger import configure_logging
 from lambkin.sdk_options import SDK_OPTIONS
+
+logger = logging.getLogger(__name__)
 
 
 def _show_options(fn) -> None:
@@ -114,6 +118,9 @@ def benchmark(variants, num_iterations):
                 sys.exit(0)
             log_level = options.get("log_level", defaults.LOG_LEVEL)
             configure_logging(log_level)
+            # Calculate total runs for logging purposes.
+            total_runs = len(variants) * num_iterations
+            logger.info("Starting benchmark: %d run(s) total.", total_runs)
             source = Source(path=inspect.getfile(fn))
             # The base context creates a directory for variant 1 / iteration 1
             # containing a metadata file with the information available at this
@@ -132,8 +139,19 @@ def benchmark(variants, num_iterations):
                 # TODO(teresa-ortega): Consider an alternative approach for managing
                 # the base context.
                 resolved_inputs = inputs.resolve(base_ctx)
+                variants_map = {
+                    f"var_{i + 1}": variant for i, variant in enumerate(variants)
+                }
+                variants_map_path = base_ctx.output.base_dir / "variants.yaml"
+                with open(variants_map_path, "w") as f:
+                    yaml.dump(
+                        variants_map, f, default_flow_style=False, sort_keys=False
+                    )
             for variant_index, variant in enumerate(variants):
                 for iteration in range(num_iterations):
+                    # Log the current run number and total runs to track progress.
+                    current_run = variant_index * num_iterations + iteration + 1
+                    logger.info("Benchmark run %d/%d", current_run, total_runs)
                     with Context(
                         variant=variant,
                         iteration=iteration,

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -62,7 +62,7 @@ def _format_elapsed(seconds: float) -> str:
     durations are truncated to whole seconds.
 
     Args:
-        seconds: Elapsed time in seconds, as returned by ``time.monotonic()``.
+        seconds (float): Elapsed time in seconds, as returned by ``time.monotonic()``.
 
     Returns:
         A human-readable elapsed time string.

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -156,11 +156,12 @@ def benchmark(variants, num_iterations):
             total_runs = len(variants) * num_iterations
             logger.info("Starting benchmark: %d run(s) total.", total_runs)
             source = Source(path=inspect.getfile(fn))
-            # The base context creates a directory for variant 1 / iteration 1
+
+            # The base context is used to resolve inputs and write variants.yaml.
+            # A side effect is that creates a directory for variant 1 / iteration 1
             # containing a metadata file with the information available at this
-            # point in time.
-            # This directory will later be overwritten with the
-            # actual data collected for variant 1 / iteration 1 during
+            # point in time. However, this directory will later be overwritten
+            # with the actual data collected for variant 1 / iteration 1 during
             # execution.
             with Context(
                 variant={},
@@ -181,6 +182,7 @@ def benchmark(variants, num_iterations):
                     yaml.dump(
                         variants_map, f, default_flow_style=False, sort_keys=False
                     )
+
             # Calculate start time
             start_time = time.monotonic()
             # Loop over variants and iterations, creating a new Context for each run.

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from lambkin.common import defaults
 from lambkin.core.ctx.context import Context
@@ -290,3 +291,20 @@ def test_parse_options_log_level_has_a_default():
     result = _parse_options(fn, [])
     assert "log_level" in result
     assert result["log_level"] == defaults.LOG_LEVEL
+
+
+def test_benchmark_writes_variants_yaml(variants, tmp_path):
+    """Benchmark writes a variants.yaml file mapping var_N to variant dicts."""
+
+    @benchmark(variants=variants, num_iterations=1)
+    def fn(ctx):
+        pass
+
+    fn(output_dir=tmp_path)
+
+    variants_file = tmp_path / "variants.yaml"
+    assert variants_file.exists()
+
+    content = yaml.safe_load(variants_file.read_text())
+    expected = {f"var_{i + 1}": variant for i, variant in enumerate(variants)}
+    assert content == expected

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -22,8 +22,27 @@ import pytest
 from lambkin.common import defaults
 from lambkin.core.ctx.context import Context
 from lambkin.core.ctx.source import Source
-from lambkin.core.decorators.benchmark import _parse_options, benchmark
+from lambkin.core.decorators.benchmark import _format_elapsed, _parse_options, benchmark
 from lambkin.core.decorators.option import option
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [
+        (0.0, "0.0000s"),
+        (0.0023, "0.0023s"),
+        (59.9999, "59.9999s"),
+        (60.0, "1m 00s"),
+        (103.0, "1m 43s"),
+        (3600.0, "1h 00m 00s"),
+        (3661.0, "1h 01m 01s"),
+        (86400.0, "1d 00h 00m 00s"),
+        (2 * 86400 + 3 * 3600 + 15 * 60 + 7, "2d 03h 15m 07s"),
+    ],
+)
+def test_format_elapsed(seconds, expected):
+    """_format_elapsed formats durations correctly across all time scales."""
+    assert _format_elapsed(seconds) == expected
 
 
 @pytest.fixture


### PR DESCRIPTION
### Proposed changes

This PR adds three log messages to the benchmark execution loop:

- `INFO` before the loop starts with the total number of runs.
- `INFO` per run with the current run count (e.g. 5/40).
- `INFO` per run with the time it took to finish the benchmark.

For the last one, a fully tested function to format the elapsed time into a human user friendly format has been added.

Additional changes focus on writing a `variants.yaml` file to the results base directory mapping each `var_N` folder to its variant parameters, making it easier to identify what each variant folder corresponds to without digging into individual iteration metadata files. 

Documentation is updated accordingly to explain this newly added output. And spacing is standarized.

Minor: adds iteration to the benchmark log info statement.

#### How to Test

Run the benchmark in dry run mode:

```bash
uv run lambkin examples/beluga/beluga_benchmark.py --dry-run
```

Expect to see the 2 newly added info messages and the `results/variants.yaml` file.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes.

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Additional comments

N/A
