### PR TITLE
Phase 5: Replace OutputInfo in favor of RunPaths and update defaults

### DIFF
--- a/src/lambkin/common/defaults.py
+++ b/src/lambkin/common/defaults.py
@@ -14,9 +14,25 @@
 
 """Default values shared across the lambkin SDK."""
 
-DRY_RUN: bool = False
-SIGTERM_GRACE_PERIOD: float = 3.0
-SIGKILL_GRACE_PERIOD: float = 5.0
-CGROUP_POLL_INTERVAL: float = 0.05
-LOG_OUTPUT: str = "file"
-LOG_LEVEL: str = "info"
+from typing import Final
+
+# Default name for the benchmarks output directory.
+BENCHMARKS_DIRNAME: Final[str] = "results"
+
+# If True, commands are logged but not executed.
+DRY_RUN: Final[bool] = False
+
+# Seconds to wait after SIGTERM before sending SIGKILL.
+SIGTERM_GRACE_PERIOD: Final[float] = 3.0
+
+# Seconds to wait after SIGKILL before giving up.
+SIGKILL_GRACE_PERIOD: Final[float] = 5.0
+
+# Polling interval in seconds when waiting for cgroup processes to exit.
+CGROUP_POLL_INTERVAL: Final[float] = 0.05
+
+# Where to route process output. Either 'file' or 'console'.
+LOG_OUTPUT: Final[str] = "file"
+
+# Default log level for lambkin SDK output.
+LOG_LEVEL: Final[str] = "info"

--- a/src/lambkin/core/ctx/__init__.py
+++ b/src/lambkin/core/ctx/__init__.py
@@ -19,9 +19,11 @@ for a single (variation, iteration) run.
 """
 
 from .context import Context
+from .paths import RunPaths
 from .source import Source
 
 __all__ = [
     "Context",
+    "RunPaths",
     "Source",
 ]

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -38,43 +38,8 @@ from lambkin.core.process.cgroup import (
 )
 from lambkin.core.shell import ShellProxy
 
+from .paths import RunPaths
 from .source import Source
-
-
-class OutputInfo:
-    """Output paths for this variant + iteration.
-
-    Folders are created lazily — only when the path is first accessed.
-
-    Attributes:
-        base_dir: Base output folder for the benchmark (e.g. results/).
-        variant_dir: Root folder for this variant (e.g. results/var_1/).
-        iteration_dir: Folder for the current iteration (e.g. results/var_1/iter_1/).
-    """
-
-    def __init__(self, base_dir: Path, variant_dir: Path, iteration_dir: Path) -> None:
-        """Initialize the output paths for one (variant, iteration) pair.
-
-        Args:
-            base_dir (Path): Base output folder for benchmark.(e.g. results/).
-            variant_dir (Path): Root output folder for this variant
-                (e.g. results/var_1/).
-            iteration_dir (Path): Output folder for the
-                current iteration (e.g. results/var_1/iter_1/).
-        """
-        self.variant_dir = Path(variant_dir)
-        self.base_dir = Path(base_dir)
-        self.iteration_dir = Path(iteration_dir)
-
-
-def _variant_folder_name(index: int) -> str:
-    """Build the variant folder name from its index."""
-    return f"var_{index + 1}"
-
-
-def _iteration_folder_name(iteration: int) -> str:
-    """Build the per-iteration folder name."""
-    return f"iter_{iteration + 1}"
 
 
 @dataclass(frozen=True)
@@ -86,7 +51,6 @@ class Context:
     folders on disk.
 
     Attributes:
-        BENCHMARKS_DIRNAME (str): Name for the benchmarks directory.
         variation: Namespaced algorithm parameters for this run.
             All key-value pairs from the variant dict are exposed as attributes.
         source: Source object describing the benchmark script being executed.
@@ -94,9 +58,8 @@ class Context:
         options: Namespaced runtime options.
             All key-value pairs from the options dict are exposed as attributes.
         output: Namespaced output paths.
+        paths: Output paths for this (variant, iteration) run.
     """
-
-    BENCHMARKS_DIRNAME = "results"
 
     def __init__(
         self,
@@ -104,9 +67,9 @@ class Context:
         iteration: int,
         options: dict[str, Any],
         source: Source,
+        base_dir: Path | str,
         inputs: SimpleNamespace | None = None,
         variant_index: int = 0,
-        output_dir: Path | str | None = None,
     ) -> None:
         """Initialize a Context for one (variant, iteration) benchmark run.
 
@@ -121,19 +84,18 @@ class Context:
             iteration (int): Zero-based repetition index within this variant.
                 Controls the ``iter_<N>`` subfolder name under the variant
                 directory, where ``N = iteration + 1``.
+            options (dict): Runtime options, as defined by the user.
+                All key-value pairs are exposed as attributes on ``ctx.options``.
             source (Source): Source object describing the benchmark script being
                 executed. Its parent directory is used as the default output
                 directory.
-            options (dict): Runtime options, as defined by the user.
-                All key-value pairs are exposed as attributes on ``ctx.options``.
+            base_dir: Root directory for all benchmark results.
             inputs (SimpleNamespace | None): Namespaced input information.
                 Defaults to None.
             variant_index (int): Zero-based index of this variant within the
                 benchmark sweep. Controls the ``var_<N>`` subfolder name under
                 the output directory, where ``N = variant_index + 1``.
                 Defaults to 0.
-            output_dir (Path | str | None): Root directory for all benchmark
-                results. If not provided, defaults to ``source.path.parent``.
         """
         # ctx.variant
         object.__setattr__(self, "variant", SimpleNamespace(**variant))
@@ -153,35 +115,18 @@ class Context:
         # ctx._variant_index
         object.__setattr__(self, "_variant_index", variant_index)
 
-        # TODO(teresa-ortega): Consider moving path construction logic into
-        # OutputInfo itself, giving it a constructor that takes base_dir,
-        # variation_index, and iteration and derives variation_dir and
-        # iteration_dir internally. This would make OutputInfo a cohesive object
-        # that owns everything path-related
-
-        # ctx.output
-        base = (
-            Path(output_dir)
-            if output_dir
-            else source.path.parent / Context.BENCHMARKS_DIRNAME
-        )
-        variant_dir = base / _variant_folder_name(variant_index)
-        iteration_dir = variant_dir / _iteration_folder_name(iteration)
+        # ctx.paths — derived internally from base_dir and indices
         object.__setattr__(
             self,
-            "output",
-            OutputInfo(
-                base_dir=base,
-                variant_dir=variant_dir,
-                iteration_dir=iteration_dir,
-            ),
+            "paths",
+            RunPaths.from_indices(base_dir, variant_index, iteration),
         )
 
         self._setup_directories()
 
         iteration_cgroup = make_iteration_cgroup(
             find_delegated_cgroup(),
-            iteration_dir,
+            self.paths.iteration_dir,
         )
         object.__setattr__(self, "_iteration_cgroup", iteration_cgroup)
         # ctx.shell
@@ -190,7 +135,7 @@ class Context:
             "shell",
             ShellProxy(
                 dry_run=getattr(self.options, "dry_run", defaults.DRY_RUN),
-                cwd=iteration_dir,
+                cwd=self.paths.iteration_dir,
                 cgroup=iteration_cgroup,
                 log_output=getattr(self.options, "log_output", defaults.LOG_OUTPUT),
             ),
@@ -213,19 +158,19 @@ class Context:
             "options": vars(self.options),
             "source": str(self.source.path),
             "output": {
-                "base_dir": str(self.output.base_dir),
-                "variant_dir": str(self.output.variant_dir),
-                "iteration_dir": str(self.output.iteration_dir),
+                "base_dir": str(self.paths.base_dir),
+                "variant_dir": str(self.paths.variant_dir),
+                "iteration_dir": str(self.paths.iteration_dir),
             },
         }
-        meta_path = self.output.iteration_dir / "lambkin_metadata.yaml"
+        meta_path = self.paths.iteration_dir / "lambkin_metadata.yaml"
         with open(meta_path, "w") as f:
             yaml.dump(metadata, f, default_flow_style=False, sort_keys=False)
 
     def _setup_directories(self) -> None:
         """Create variant and iteration directories."""
-        self.output.variant_dir.mkdir(parents=True, exist_ok=True)
-        self.output.iteration_dir.mkdir(parents=True, exist_ok=True)
+        self.paths.variant_dir.mkdir(parents=True, exist_ok=True)
+        self.paths.iteration_dir.mkdir(parents=True, exist_ok=True)
 
     def __repr__(self) -> str:
         """Return a human-readable summary of the Context state."""
@@ -237,8 +182,8 @@ class Context:
             f"  source        = {self.source},\n"
             f"  inputs        = {inputs},\n"
             f"  options       = {vars(self.options)},\n"
-            f"  variant_dir   = {self.output.variant_dir},\n"
-            f"  iteration_dir = {self.output.iteration_dir}\n"
+            f"  variant_dir   = {self.paths.variant_dir},\n"
+            f"  iteration_dir = {self.paths.iteration_dir}\n"
             f")"
         )
 

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -89,14 +89,14 @@ class Context:
             options (dict): Runtime options, as defined by the user.
                 All key-value pairs are exposed as attributes on ``ctx.options``.
             source (Source): Source object describing the benchmark script being
-                executed. Its parent directory is used as the default output
+                executed. Its parent directory is used as the default output base
                 directory.
             base_dir (Path | str): Root directory for all benchmark results.
             inputs (SimpleNamespace | None): Namespaced input information.
                 Defaults to None.
             variant_index (int): Zero-based index of this variant within the
                 benchmark sweep. Controls the ``var_<N>`` subfolder name under
-                the output directory, where ``N = variant_index + 1``.
+                the output base directory, where ``N = variant_index + 1``.
                 Defaults to 0.
         """
         # ctx.variant
@@ -156,7 +156,7 @@ class Context:
         """Write a YAML metadata file to the iteration output directory.
 
         Serializes run identity, parameters, source, and output paths
-        to ``metadata.yaml`` inside ``output.iteration_dir``. The file
+        to ``metadata.yaml`` inside ``paths.iteration_dir``. The file
         is written once at context creation time and is not updated afterwards.
         """
         metadata = {
@@ -166,7 +166,7 @@ class Context:
             "variant": vars(self.variant),
             "options": vars(self.options),
             "source": str(self.source.path),
-            "output": {
+            "paths": {
                 "base_dir": str(self.paths.base_dir),
                 "variant_dir": str(self.paths.variant_dir),
                 "iteration_dir": str(self.paths.iteration_dir),

--- a/src/lambkin/core/ctx/context.py
+++ b/src/lambkin/core/ctx/context.py
@@ -46,19 +46,21 @@ from .source import Source
 class Context:
     """Carries all namespaced information for one benchmark variant.
 
-    Builds all namespaced sub-objects (variant, inputs, options, output)
+    Builds all namespaced sub-objects (variant, inputs, options, paths)
     from the given parameters and automatically creates the required output
     folders on disk.
 
     Attributes:
-        variation: Namespaced algorithm parameters for this run.
+        variant: Namespaced algorithm parameters for this run.
             All key-value pairs from the variant dict are exposed as attributes.
-        source: Source object describing the benchmark script being executed.
-        inputs: Namespaced input information.
         options: Namespaced runtime options.
             All key-value pairs from the options dict are exposed as attributes.
-        output: Namespaced output paths.
+        source: Source object describing the benchmark script being executed.
+        inputs: Namespaced input information.
+        iteration: Zero-based repetition index within this variant.
         paths: Output paths for this (variant, iteration) run.
+        shell: ShellProxy instance configured for this run, with working directory
+            set to the iteration output folder and cgroup set to the iteration cgroup.
     """
 
     def __init__(
@@ -89,7 +91,7 @@ class Context:
             source (Source): Source object describing the benchmark script being
                 executed. Its parent directory is used as the default output
                 directory.
-            base_dir: Root directory for all benchmark results.
+            base_dir (Path | str): Root directory for all benchmark results.
             inputs (SimpleNamespace | None): Namespaced input information.
                 Defaults to None.
             variant_index (int): Zero-based index of this variant within the
@@ -122,13 +124,13 @@ class Context:
             RunPaths.from_indices(base_dir, variant_index, iteration),
         )
 
-        self._setup_directories()
-
+        # Find cgroup for the current iteration
         iteration_cgroup = make_iteration_cgroup(
             find_delegated_cgroup(),
             self.paths.iteration_dir,
         )
         object.__setattr__(self, "_iteration_cgroup", iteration_cgroup)
+
         # ctx.shell
         object.__setattr__(
             self,
@@ -140,7 +142,14 @@ class Context:
                 log_output=getattr(self.options, "log_output", defaults.LOG_OUTPUT),
             ),
         )
+
+        # Save the start time for this run, to be written to metadata
         object.__setattr__(self, "_started_at", datetime.datetime.now().isoformat())
+
+        # Setup directories
+        self._setup_directories()
+
+        # Write metadata after all attributes are set up
         self._write_metadata()
 
     def _write_metadata(self) -> None:

--- a/src/lambkin/core/ctx/paths.py
+++ b/src/lambkin/core/ctx/paths.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark run output paths.
+
+Defines RunPaths, a value object that owns all path construction logic
+for a single (variant, iteration) benchmark run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class RunPaths:
+    """Output paths for one (variant, iteration) benchmark run.
+
+    Attributes:
+        base_dir: Base output folder for the benchmark (e.g. results/).
+        variant_dir: Root folder for this variant (e.g. results/var_1/).
+        iteration_dir: Folder for the current iteration (e.g. results/var_1/iter_1/).
+    """
+
+    def __init__(self, base_dir: Path, variant_dir: Path, iteration_dir: Path) -> None:
+        """Initialize output paths directly from fully resolved paths.
+
+        Args:
+            base_dir: Base output folder for the benchmark (e.g. results/).
+            variant_dir: Root output folder for this variant (e.g. results/var_1/).
+            iteration_dir: Output folder for the current iteration
+                (e.g. results/var_1/iter_1/).
+        """
+        self.base_dir = Path(base_dir)
+        self.variant_dir = Path(variant_dir)
+        self.iteration_dir = Path(iteration_dir)
+
+    @classmethod
+    def from_indices(
+        cls,
+        base_dir: Path | str,
+        variant_index: int,
+        iteration: int,
+    ) -> RunPaths:
+        """Derive output paths from a base directory and numeric indices.
+
+        Constructs the canonical variant and iteration subdirectory names
+        from zero-based indices (e.g. var_1/iter_1) and returns a fully
+        resolved RunPaths.
+
+        Args:
+            base_dir: Root directory for all benchmark results.
+            variant_index: Zero-based variant index.
+            iteration: Zero-based iteration index.
+
+        Returns:
+            A fully resolved RunPaths for this (variant, iteration) pair.
+        """
+        base = Path(base_dir)
+        variant_dir = base / f"var_{variant_index + 1}"
+        iteration_dir = variant_dir / f"iter_{iteration + 1}"
+        return cls(base_dir=base, variant_dir=variant_dir, iteration_dir=iteration_dir)
+
+    def __repr__(self) -> str:
+        """Return a human-readable summary of the RunPaths state."""
+        return (
+            f"RunPaths("
+            f"base_dir={self.base_dir}, "
+            f"variant_dir={self.variant_dir}, "
+            f"iteration_dir={self.iteration_dir})"
+        )

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -184,7 +184,7 @@ def benchmark(variants, num_iterations):
                 variants_map = {
                     f"var_{i + 1}": variant for i, variant in enumerate(variants)
                 }
-                variants_map_path = base_ctx.output.base_dir / "variants.yaml"
+                variants_map_path = base_ctx.paths.base_dir / "variants.yaml"
                 with open(variants_map_path, "w") as f:
                     yaml.dump(
                         variants_map, f, default_flow_style=False, sort_keys=False

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -157,6 +157,13 @@ def benchmark(variants, num_iterations):
             logger.info("Starting benchmark: %d run(s) total.", total_runs)
             source = Source(path=inspect.getfile(fn))
 
+            # Determine base_dir for all benchmark outputs.
+            base_dir = (
+                output_dir
+                if output_dir
+                else source.path.parent / defaults.BENCHMARKS_DIRNAME
+            )
+
             # The base context is used to resolve inputs and write variants.yaml.
             # A side effect is that creates a directory for variant 1 / iteration 1
             # containing a metadata file with the information available at this
@@ -168,8 +175,8 @@ def benchmark(variants, num_iterations):
                 iteration=0,
                 options=options,
                 source=source,
+                base_dir=base_dir,
                 variant_index=0,
-                output_dir=output_dir,
             ) as base_ctx:
                 # TODO(teresa-ortega): Consider an alternative approach for managing
                 # the base context.
@@ -196,9 +203,9 @@ def benchmark(variants, num_iterations):
                         iteration=iteration,
                         options=options,
                         source=source,
+                        base_dir=base_dir,
                         inputs=resolved_inputs,
                         variant_index=variant_index,
-                        output_dir=output_dir,
                     ) as ctx:
                         fn(ctx)
             # Calculate total elapsed time

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -144,7 +144,7 @@ def benchmark(variants, num_iterations):
         inputs = InputRegistry()
 
         @functools.wraps(fn)
-        def wrapper(args=None, output_dir=None):
+        def wrapper(args=None, base_dir=None):
             cli_args = sys.argv[1:] if args is None else args
             options = _parse_options(fn, cli_args)
             if options.get("show_options"):
@@ -159,8 +159,8 @@ def benchmark(variants, num_iterations):
 
             # Determine base_dir for all benchmark outputs.
             base_dir = (
-                output_dir
-                if output_dir
+                base_dir
+                if base_dir
                 else source.path.parent / defaults.BENCHMARKS_DIRNAME
             )
 

--- a/src/lambkin/sdk_options.py
+++ b/src/lambkin/sdk_options.py
@@ -63,7 +63,9 @@ SDK_OPTIONS: tuple[click.Option, ...] = (
     ),
     click.Option(
         ["--log-level"],
-        type=click.Choice(["debug", "info", "warning", "error"], case_sensitive=False),
+        type=click.Choice(
+            ["debug", "info", "warning", "error", "critical"], case_sensitive=False
+        ),
         default=defaults.LOG_LEVEL,
         show_default=True,
         help="Log level for lambkin SDK output.",

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -127,7 +127,7 @@ def test_benchmark_loops_over_variants_and_iterations(variants, tmp_path):
     def fn(ctx):
         calls.append(ctx)
 
-    fn(output_dir=tmp_path)
+    fn(base_dir=tmp_path)
     assert len(calls) == 6
 
 
@@ -139,7 +139,7 @@ def test_benchmark_variant_attributes_are_correct(variants, tmp_path):
     def fn(ctx):
         contexts.append(ctx)
 
-    fn(output_dir=tmp_path)
+    fn(base_dir=tmp_path)
     assert contexts[0].variant.sensor_model == "beam"
     assert contexts[0].variant.num_particles == 10
     assert contexts[1].variant.sensor_model == "likelihood"
@@ -156,7 +156,7 @@ def test_benchmark_options_defaults_injected(variants, tmp_path):
     def fn(ctx):
         contexts.append(ctx)
 
-    fn(output_dir=tmp_path)
+    fn(base_dir=tmp_path)
     assert contexts[0].options.clock_rate == 100.0
     assert contexts[0].options.sensor_topic == "/scan"
 
@@ -170,7 +170,7 @@ def test_benchmark_options_injected_via_args(variants, tmp_path):
     def fn(ctx):
         contexts.append(ctx)
 
-    fn(args=["--clock-rate", "50.0"], output_dir=tmp_path)
+    fn(args=["--clock-rate", "50.0"], base_dir=tmp_path)
     assert contexts[0].options.clock_rate == 50.0
 
 
@@ -182,12 +182,12 @@ def test_benchmark_source_path_points_to_benchmark_script(variants, tmp_path):
     def fn(ctx):
         contexts.append(ctx)
 
-    fn(output_dir=tmp_path)
+    fn(base_dir=tmp_path)
     assert contexts[0].source.path == Path(__file__)
 
 
-def test_benchmark_default_output_dir_uses_source_path(variants, tmp_path):
-    """When output_dir=None, output is resolved relative to the source path."""
+def test_benchmark_default_base_dir_uses_source_path(variants, tmp_path):
+    """When base_dir=None, output is resolved relative to the source path."""
     contexts = []
     fake_script = tmp_path / "my_benchmark.py"
     fake_script.touch()

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -21,7 +21,6 @@ import pytest
 import yaml
 
 from lambkin.common import defaults
-from lambkin.core.ctx.context import Context
 from lambkin.core.ctx.source import Source
 from lambkin.core.decorators.benchmark import _format_elapsed, _parse_options, benchmark
 from lambkin.core.decorators.option import option
@@ -201,7 +200,7 @@ def test_benchmark_default_output_dir_uses_source_path(variants, tmp_path):
     with patch("lambkin.core.decorators.benchmark.Source", return_value=fake_source):
         fn()
 
-    assert contexts[0].output.base_dir == tmp_path / Context.BENCHMARKS_DIRNAME
+    assert contexts[0].paths.base_dir == tmp_path / defaults.BENCHMARKS_DIRNAME
     assert contexts[0].source.path == fake_script
 
 

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -299,7 +299,7 @@ def test_benchmark_writes_variants_yaml(variants, tmp_path):
     def fn(ctx):
         pass
 
-    fn(output_dir=tmp_path)
+    fn(base_dir=tmp_path)
 
     variants_file = tmp_path / "variants.yaml"
     assert variants_file.exists()

--- a/test/core/test_context.py
+++ b/test/core/test_context.py
@@ -47,9 +47,9 @@ def ctx(tmp_path, base_variant, base_options, base_source):
     return Context(
         variant=base_variant,
         iteration=0,
-        output_dir=tmp_path,
         options=base_options,
         source=base_source,
+        base_dir=tmp_path,
     )
 
 
@@ -81,18 +81,19 @@ def test_output_dirs_are_created_on_instantiation(
     ctx = Context(
         variant=variant,
         iteration=iteration,
-        output_dir=tmp_path,
         options=base_options,
         source=base_source,
+        base_dir=tmp_path,
         variant_index=variant_index,
     )
     expected_variant_dir = tmp_path / f"var_{variant_index + 1}"
     expected_iteration_dir = expected_variant_dir / f"iter_{iteration + 1}"
 
-    assert ctx.output.variant_dir == expected_variant_dir
-    assert ctx.output.iteration_dir == expected_iteration_dir
-    assert ctx.output.variant_dir.exists()
-    assert ctx.output.iteration_dir.exists()
+    assert ctx.paths.base_dir == tmp_path
+    assert ctx.paths.variant_dir == expected_variant_dir
+    assert ctx.paths.iteration_dir == expected_iteration_dir
+    assert ctx.paths.variant_dir.exists()
+    assert ctx.paths.iteration_dir.exists()
     assert ctx.variant.sensor_model == expected_sensor
     assert ctx.variant.num_particles == expected_particles
 
@@ -125,9 +126,9 @@ def test_variation_attributes(
     ctx = Context(
         variant=variant,
         iteration=0,
-        output_dir=tmp_path,
         options=base_options,
         source=base_source,
+        base_dir=tmp_path,
     )
     for key, value in expected_attrs.items():
         assert getattr(ctx.variant, key) == value
@@ -163,9 +164,9 @@ def test_options_attributes(
     ctx = Context(
         variant=base_variant,
         iteration=0,
-        output_dir=tmp_path,
         options=options,
         source=base_source,
+        base_dir=tmp_path,
     )
     assert ctx.options.clock == expected_clock
     assert ctx.options.qos_option_path == expected_qos
@@ -188,30 +189,11 @@ def test_iteration_stored(tmp_path, base_variant, base_options, base_source, ite
     ctx = Context(
         variant=base_variant,
         iteration=iteration,
-        output_dir=tmp_path,
         options=base_options,
         source=base_source,
+        base_dir=tmp_path,
     )
     assert ctx.iteration == iteration
-
-
-def test_context_default_output_dir(tmp_path):
-    """Default output_dir resolves relative to the benchmark script.
-
-    When output_dir is not provided, it defaults to source.path.parent /
-    Context.BENCHMARKS_DIRNAME.
-    """
-    script = tmp_path / "my_benchmark.py"
-    script.touch()
-
-    source = Source(path=script)
-    ctx = Context(
-        variant={"sensor_model": "beam", "num_particles": 10},
-        iteration=0,
-        options={},
-        source=source,
-    )
-    assert ctx.output.base_dir == tmp_path / Context.BENCHMARKS_DIRNAME
 
 
 def test_context_is_immutable(tmp_path):
@@ -222,8 +204,8 @@ def test_context_is_immutable(tmp_path):
         iteration=0,
         options={"dry_run": True},
         source=source,
+        base_dir=tmp_path,
         variant_index=0,
-        output_dir=tmp_path,
     )
 
     with pytest.raises(AttributeError):

--- a/test/core/test_input.py
+++ b/test/core/test_input.py
@@ -138,7 +138,7 @@ def test_ctx_inputs_populated_before_fn_runs(variant):
     def dataset(ctx):
         return "path/to/dataset.mcap"
 
-    nominal(output_dir="/tmp")
+    nominal(base_dir="/tmp")
     assert seen == ["path/to/dataset.mcap"]
 
 
@@ -158,7 +158,7 @@ def test_multiple_inputs_all_injected(variant):
     def map(ctx):
         return "path/to/map.yaml"
 
-    nominal(output_dir="/tmp")
+    nominal(base_dir="/tmp")
     assert seen == [("path/to/dataset.mcap", "path/to/map.yaml")]
 
 
@@ -182,6 +182,6 @@ def test_input_hook_called_once_regardless_of_variants_and_iterations():
         call_count += 1
         return "path/to/dataset.mcap"
 
-    nominal(output_dir="/tmp")
+    nominal(base_dir="/tmp")
 
     assert call_count == 1


### PR DESCRIPTION
### Proposed changes

This PR does the following:
- Documents `defaults.py` and makes them type-safe thanks to `Final` qualifier.
- Moves `BENCHMARKS_DIRNAME` constant from context `OutputInfo` into `defaults.py`.
- Replaces `OutputInfo` for `RunPaths` (which is moved to its own file `paths.py`) to avoid collision with incoming output decorator. Init now exports this class.
- Removed TODO comment in Context as now ownership of the path construction logic is moved to `RunPaths` thanks to `from_indices` function. `ctx.output` attribute has been renamed to `ctx.paths`, and `output_dir` constructor attribute to `base_dir`.
- Added log level `critical` choice in `sdk_options.py` as it was missing.
- Tests have been updated accordingly to account for all the changes.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 **Breaking change!** N/A

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments

N/A
