### PR TITLE
Phase 5: Select variants via CLI

### DIFF
--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -103,6 +103,67 @@ def _show_options(fn) -> None:
     click.echo(formatter.getvalue(), nl=False)
 
 
+def _list_variants(variants) -> None:
+    """Print all variants with their var_N number to stdout."""
+    width = len(str(len(variants)))
+    click.echo("Available variants:")
+    for i, variant in enumerate(variants):
+        prefix = f"  [{i + 1:{width}}]  "
+        indent = " " * len(prefix)
+        pairs = list(variant.items())
+        click.echo(f"{prefix}{pairs[0][0]}={pairs[0][1]}")
+        for k, v in pairs[1:]:
+            click.echo(f"{indent}{k}={v}")
+        click.echo()
+
+
+def _parse_index_list(raw: str, label: str) -> set[int]:
+    """Parse a comma-separated string of var_N folder numbers into a set.
+
+    Tokens can be plain numbers or ranges in start:end format (inclusive on
+    both ends), e.g. "3:5,42" expands to {3, 4, 5, 42}.
+
+    Args:
+        raw: Comma-separated numbers or ranges matching folder names, e.g.
+            "3:5,42" to select var_3/, var_4/, var_5/, var_42/.
+        label: Human-readable name used in error messages (e.g. "variant").
+
+    Returns:
+        The parsed numbers.
+
+    Raises:
+        click.BadParameter: If any token is not a positive integer or a valid
+            start:end range.
+    """
+    result = set()
+    for token in raw.split(","):
+        token = token.strip()
+        if ":" in token:
+            parts = token.split(":")
+            if len(parts) != 2 or not all(p.isdigit() for p in parts):
+                raise click.BadParameter(
+                    f"Invalid {label} range {token!r}: must be start:end "
+                    f"with positive integers (e.g. 3:5).",
+                    param_hint=f"--{label}s",
+                )
+            start, end = int(parts[0]), int(parts[1])
+            if start < 1 or end < start:
+                raise click.BadParameter(
+                    f"Invalid {label} range {token!r}: start must be >= 1 "
+                    f"and end must be >= start.",
+                    param_hint=f"--{label}s",
+                )
+            result.update(range(start, end + 1))
+        else:
+            if not token.isdigit() or int(token) < 1:
+                raise click.BadParameter(
+                    f"Invalid {label} index {token!r}: must be a positive integer.",
+                    param_hint=f"--{label}s",
+                )
+            result.add(int(token))
+    return result
+
+
 def _parse_options(fn, cli_args):
     """Parse CLI options from fn.__lambkin_options__ and return a dict."""
     user_options = getattr(fn, "__lambkin_options__", [])
@@ -150,11 +211,39 @@ def benchmark(variants, num_iterations):
             if options.get("show_options"):
                 _show_options(fn)
                 sys.exit(0)
+            if options.get("list_variants"):
+                _list_variants(variants)
+                sys.exit(0)
             log_level = options.get("log_level", defaults.LOG_LEVEL)
+            cli_variants = options.get("variants")
+
+            # Configure the logging level for the SDK.
             configure_logging(log_level)
-            # Calculate total runs for logging purposes.
-            total_runs = len(variants) * num_iterations
-            logger.info("Starting benchmark: %d run(s) total.", total_runs)
+
+            # Resolve variant and iteration filters from CLI options.
+            # Numbers match the var_N / iter_N folder names on disk.
+            selected_variants = (
+                _parse_index_list(cli_variants, "variant") if cli_variants else None
+            )
+
+            logger.info(
+                "Starting benchmark: %d variant(s), %d iteration(s) each.",
+                len(variants), num_iterations,
+            )
+            if selected_variants:
+                selected_count = len(selected_variants)
+                logger.info(
+                    "Selected variants: %s (%d/%d).",
+                    ", ".join(f"var_{i}" for i in sorted(selected_variants)),
+                    selected_count,
+                    len(variants),
+                )
+            else:
+                selected_count = len(variants)
+            total_runs = selected_count * num_iterations
+            current_run = 0
+
+            # Create Source object
             source = Source(path=inspect.getfile(fn))
 
             # Determine base_dir for all benchmark outputs.
@@ -192,11 +281,17 @@ def benchmark(variants, num_iterations):
 
             # Calculate start time
             start_time = time.monotonic()
+
             # Loop over variants and iterations, creating a new Context for each run.
+            # variant_index is always the original 0-based position in the full
+            # variants list so that output folder numbers (var_N) are stable
+            # regardless of which subset is selected at the CLI.
             for variant_index, variant in enumerate(variants):
+                if selected_variants and (variant_index + 1) not in selected_variants:
+                    continue
                 for iteration in range(num_iterations):
                     # Log the current run number and total runs to track progress.
-                    current_run = variant_index * num_iterations + iteration + 1
+                    current_run += 1
                     logger.info("Benchmark run %d/%d", current_run, total_runs)
                     with Context(
                         variant=variant,
@@ -208,6 +303,7 @@ def benchmark(variants, num_iterations):
                         variant_index=variant_index,
                     ) as ctx:
                         fn(ctx)
+
             # Calculate total elapsed time
             logger.info(
                 "Benchmark finished in %s.",

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -43,45 +43,22 @@ from lambkin.core.ctx.source import Source
 from lambkin.core.decorators.input import InputRegistry
 from lambkin.logger import configure_logging
 from lambkin.sdk_options import SDK_OPTIONS
+from lambkin.utils import format_elapsed_time
 
 logger = logging.getLogger(__name__)
 
 
-def _format_elapsed(seconds: float) -> str:
-    """Format an elapsed time into a human-readable string.
+def _show_options(fn) -> None:
+    """Print SDK and user-defined options to stdout.
 
-    Scales the output unit to the duration so the result is always easy to
-    read at a glance, from sub-second runs to multi-day sweeps:
-
-    - Under 60 s:  ``'0.0023s'``
-    - Under 1 h:   ``'45m 03s'``
-    - Under 1 day: ``'2h 15m 07s'``
-    - 1 day or more: ``'2d 03h 15m 07s'``
-
-    Sub-second precision is kept only for runs under 60 seconds; longer
-    durations are truncated to whole seconds.
+    Displays two sections: SDK options (always available) and custom options
+    registered via ``@lambkin.option``. Each option is shown with its flag
+    name, help text, and default value if one is set.
 
     Args:
-        seconds (float): Elapsed time in seconds, as returned by ``time.monotonic()``.
-
-    Returns:
-        A human-readable elapsed time string.
+        fn: The decorated benchmark function, which may carry a
+            ``__lambkin_options__`` attribute populated by ``@lambkin.option``.
     """
-    if seconds < 60:
-        return f"{seconds:.4f}s"
-    total = int(seconds)
-    d, remainder = divmod(total, 86400)
-    h, remainder = divmod(remainder, 3600)
-    m, s = divmod(remainder, 60)
-    if d > 0:
-        return f"{d}d {h:02d}h {m:02d}m {s:02d}s"
-    if h > 0:
-        return f"{h}h {m:02d}m {s:02d}s"
-    return f"{m}m {s:02d}s"
-
-
-def _show_options(fn) -> None:
-    """Print all options registered via @lambkin.option on fn."""
     user_options = getattr(fn, "__lambkin_options__", [])
     formatter = HelpFormatter()
     with formatter.section("SDK Options"):
@@ -103,12 +80,21 @@ def _show_options(fn) -> None:
     click.echo(formatter.getvalue(), nl=False)
 
 
-def _list_variants(variants) -> None:
-    """Print all variants with their var_N number to stdout."""
+def _show_variants(variants) -> None:
+    """Print all variants with their var_N number to stdout.
+
+    Each variant is printed as a block with its number and key=value pairs,
+    one parameter per line. The number column is padded so that all parameter
+    keys align regardless of how many digits the variant count has.
+
+    Args:
+        variants: List of variant dicts to print.
+    """
     width = len(str(len(variants)))
     click.echo("Available variants:")
     for i, variant in enumerate(variants):
-        prefix = f"  [{i + 1:{width}}]  "
+        number = f"[{i + 1}]"
+        prefix = f"  {number:<{width + 2}}  "
         indent = " " * len(prefix)
         pairs = list(variant.items())
         click.echo(f"{prefix}{pairs[0][0]}={pairs[0][1]}")
@@ -117,7 +103,7 @@ def _list_variants(variants) -> None:
         click.echo()
 
 
-def _parse_index_list(raw: str, label: str) -> set[int]:
+def _parse_index_list(raw: str, label: str, max_value: int | None = None) -> set[int]:
     """Parse a comma-separated string of var_N folder numbers into a set.
 
     Tokens can be plain numbers or ranges in start:end format (inclusive on
@@ -127,17 +113,21 @@ def _parse_index_list(raw: str, label: str) -> set[int]:
         raw: Comma-separated numbers or ranges matching folder names, e.g.
             "3:5,42" to select var_3/, var_4/, var_5/, var_42/.
         label: Human-readable name used in error messages (e.g. "variant").
+        max_value: Upper bound for all indices (inclusive). If provided, any
+            index exceeding this value raises a BadParameter error.
 
     Returns:
         The parsed numbers.
 
     Raises:
         click.BadParameter: If any token is not a positive integer or a valid
-            start:end range.
+            start:end range, or within the allowed range.
     """
     result = set()
     for token in raw.split(","):
         token = token.strip()
+        # Check if the token is a range (contains ":") or a single number, and parse
+        # accordingly.
         if ":" in token:
             parts = token.split(":")
             if len(parts) != 2 or not all(p.isdigit() for p in parts):
@@ -161,11 +151,33 @@ def _parse_index_list(raw: str, label: str) -> set[int]:
                     param_hint=f"--{label}s",
                 )
             result.add(int(token))
+    # Check that any provided indices do not exceed the maximum allowed value.
+    if max_value is not None:
+        out_of_bounds = {i for i in result if i > max_value}
+        if out_of_bounds:
+            raise click.BadParameter(
+                f"Index {', '.join(str(i) for i in sorted(out_of_bounds))} out of "
+                f"range (1-{max_value}).",
+                param_hint=f"--{label}s",
+            )
     return result
 
 
 def _parse_options(fn, cli_args):
-    """Parse CLI options from fn.__lambkin_options__ and return a dict."""
+    """Parse CLI options for a benchmark run.
+
+    Collects SDK options and any user-defined options registered on ``fn``
+    via ``@lambkin.option``, builds an internal Click command, and parses
+    the given argument list against it.
+
+    Args:
+        fn: The decorated benchmark function, which may carry a
+            ``__lambkin_options__`` attribute populated by ``@lambkin.option``.
+        cli_args: The argument list to parse, typically ``sys.argv[1:]``.
+
+    Returns:
+        A dict mapping normalized option names to their parsed values.
+    """
     user_options = getattr(fn, "__lambkin_options__", [])
     all_options = list(SDK_OPTIONS) + user_options
     if not all_options:
@@ -206,14 +218,19 @@ def benchmark(variants, num_iterations):
 
         @functools.wraps(fn)
         def wrapper(args=None, base_dir=None):
+            # Parse CLI arguments, falling back to sys.argv if no args are provided.
             cli_args = sys.argv[1:] if args is None else args
             options = _parse_options(fn, cli_args)
+
+            # Handle early-exit flags before any benchmark setup.
             if options.get("show_options"):
                 _show_options(fn)
                 sys.exit(0)
-            if options.get("list_variants"):
-                _list_variants(variants)
+            if options.get("show_variants"):
+                _show_variants(variants)
                 sys.exit(0)
+
+            # Extract SDK options for use during the benchmark run.
             log_level = options.get("log_level", defaults.LOG_LEVEL)
             cli_variants = options.get("variants")
 
@@ -223,12 +240,17 @@ def benchmark(variants, num_iterations):
             # Resolve variant and iteration filters from CLI options.
             # Numbers match the var_N / iter_N folder names on disk.
             selected_variants = (
-                _parse_index_list(cli_variants, "variant") if cli_variants else None
+                _parse_index_list(cli_variants, "variant", max_value=len(variants))
+                if cli_variants
+                else None
             )
 
+            # Log benchmark scope and compute total runs against the effective
+            # selection — all variants, or only those requested via --variants.
             logger.info(
                 "Starting benchmark: %d variant(s), %d iteration(s) each.",
-                len(variants), num_iterations,
+                len(variants),
+                num_iterations,
             )
             if selected_variants:
                 selected_count = len(selected_variants)
@@ -243,7 +265,9 @@ def benchmark(variants, num_iterations):
             total_runs = selected_count * num_iterations
             current_run = 0
 
-            # Create Source object
+            # Create the Source object from the benchmark script's path.
+            # This is used for Context construction and to derive the default base_dir
+            # when no output directory is explicitly provided.
             source = Source(path=inspect.getfile(fn))
 
             # Determine base_dir for all benchmark outputs.
@@ -304,12 +328,14 @@ def benchmark(variants, num_iterations):
                     ) as ctx:
                         fn(ctx)
 
-            # Calculate total elapsed time
+            # Calculate and print total elapsed time, useful for user introspection.
             logger.info(
                 "Benchmark finished in %s.",
-                _format_elapsed(time.monotonic() - start_time),
+                format_elapsed_time(time.monotonic() - start_time),
             )
 
+        # Expose the input registration hook so users can decorate input providers
+        # with @my_benchmark.input on the returned wrapper.
         wrapper.input = inputs.register
         return wrapper
 

--- a/src/lambkin/sdk_options.py
+++ b/src/lambkin/sdk_options.py
@@ -29,11 +29,11 @@ before parsing, so they are always available on ``ctx.options``.
         - ``--show-options``
         - ``--log-output``
         - ``--log-level``
-        - ``--list-variants``
+        - ``--show-variants``
         - ``--variants``
 
 Note:
-    ``--show-options`` and ``--list-variants`` behave like ``--help``: they
+    ``--show-options`` and ``--show-variants`` behave like ``--help``: they
     print information and exit immediately, never reaching the benchmark body.
 """
 
@@ -73,7 +73,7 @@ SDK_OPTIONS: tuple[click.Option, ...] = (
         help="Log level for lambkin SDK output.",
     ),
     click.Option(
-        ["--list-variants"],
+        ["--show-variants"],
         is_flag=True,
         default=False,
         help="Print all variants with their var_N number and exit.",

--- a/src/lambkin/sdk_options.py
+++ b/src/lambkin/sdk_options.py
@@ -29,10 +29,12 @@ before parsing, so they are always available on ``ctx.options``.
         - ``--show-options``
         - ``--log-output``
         - ``--log-level``
+        - ``--list-variants``
+        - ``--variants``
 
 Note:
-    ``--show-options`` behaves like ``--help``: it prints registered
-    options and exits immediately, never reaching the benchmark body.
+    ``--show-options`` and ``--list-variants`` behave like ``--help``: they
+    print information and exit immediately, never reaching the benchmark body.
 """
 
 import click
@@ -69,5 +71,20 @@ SDK_OPTIONS: tuple[click.Option, ...] = (
         default=defaults.LOG_LEVEL,
         show_default=True,
         help="Log level for lambkin SDK output.",
+    ),
+    click.Option(
+        ["--list-variants"],
+        is_flag=True,
+        default=False,
+        help="Print all variants with their var_N number and exit.",
+    ),
+    click.Option(
+        ["--variants"],
+        default=None,
+        help=(
+            "Comma-separated variant numbers or ranges to run, matching var_N folder "
+            "names (e.g. --variants 3:5,42 runs var_3/, var_4/, var_5/, var_42/). "
+            "Defaults to all variants."
+        ),
     ),
 )

--- a/src/lambkin/utils/__init__.py
+++ b/src/lambkin/utils/__init__.py
@@ -17,3 +17,7 @@
 Provides standalone conversion and helper tools used across the SDK layers, with
 no dependencies on core or layers internals.
 """
+
+from .utils import format_elapsed_time
+
+__all__ = ["format_elapsed_time"]

--- a/src/lambkin/utils/utils.py
+++ b/src/lambkin/utils/utils.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""General-purpose utilities for the lambkin SDK.
+
+This module provides standalone helper functions with no dependencies on
+lambkin internals. Functions here are reusable across the SDK and user
+benchmarks alike.
+"""
+
+
+def format_elapsed_time(seconds: float) -> str:
+    """Format an elapsed time into a human-readable string.
+
+    Scales the output unit to the duration so the result is always easy to
+    read at a glance, from sub-second runs to multi-day sweeps:
+
+    - Under 60 s:  ``'0.0023s'``
+    - Under 1 h:   ``'45m 03s'``
+    - Under 1 day: ``'2h 15m 07s'``
+    - 1 day or more: ``'2d 03h 15m 07s'``
+
+    Sub-second precision is kept only for runs under 60 seconds; longer
+    durations are truncated to whole seconds.
+
+    Args:
+        seconds (float): Elapsed time in seconds, as returned by ``time.monotonic()``.
+
+    Returns:
+        A human-readable elapsed time string.
+    """
+    if seconds < 60:
+        return f"{seconds:.4f}s"
+    total = int(seconds)
+    d, remainder = divmod(total, 86400)
+    h, remainder = divmod(remainder, 3600)
+    m, s = divmod(remainder, 60)
+    if d > 0:
+        return f"{d}d {h:02d}h {m:02d}m {s:02d}s"
+    if h > 0:
+        return f"{h}h {m:02d}m {s:02d}s"
+    return f"{m}m {s:02d}s"

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -17,12 +17,17 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import click
 import pytest
 import yaml
 
 from lambkin.common import defaults
 from lambkin.core.ctx.source import Source
-from lambkin.core.decorators.benchmark import _parse_options, benchmark
+from lambkin.core.decorators.benchmark import (
+    _parse_index_list,
+    _parse_options,
+    benchmark,
+)
 from lambkin.core.decorators.option import option
 
 
@@ -294,3 +299,102 @@ def test_benchmark_writes_variants_yaml(variants, tmp_path):
     content = yaml.safe_load(variants_file.read_text())
     expected = {f"var_{i + 1}": variant for i, variant in enumerate(variants)}
     assert content == expected
+
+
+@pytest.mark.parametrize(
+    "input,max_value,expected",
+    [
+        ("3", None, {3}),
+        ("1,3,5", None, {1, 3, 5}),
+        ("2:5", None, {2, 3, 4, 5}),
+        ("1:3,5", None, {1, 2, 3, 5}),
+        ("3", 3, {3}),
+    ],
+)
+def test_parse_index_list_valid(input, max_value, expected):
+    """_parse_index_list correctly parses valid inputs."""
+    assert _parse_index_list(input, "variant", max_value=max_value) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,max_value",
+    [
+        ("0", None),
+        ("-1", None),
+        ("abc", None),
+        ("5:2", None),
+        ("5", 3),
+        ("2:5", 4),
+    ],
+)
+def test_parse_index_list_invalid(raw, max_value):
+    """_parse_index_list raises BadParameter for invalid inputs."""
+    with pytest.raises(click.exceptions.BadParameter):
+        _parse_index_list(raw, "variant", max_value=max_value)
+
+
+def test_show_variants_exits_with_zero(capsys):
+    """--show-variants exits with code 0."""
+
+    @benchmark(variants=[{"a": 1}], num_iterations=1)
+    def fn(ctx):
+        pass
+
+    with pytest.raises(SystemExit) as exc:
+        fn(args=["--show-variants"])
+
+    assert exc.value.code == 0
+
+
+@pytest.mark.parametrize(
+    "variants,expected_output",
+    [
+        (
+            [{"sensor_model": "beam", "num_particles": 10}],
+            ["[1]", "sensor_model=beam", "num_particles=10"],
+        ),
+        (
+            [{"sensor_model": "beam"}, {"sensor_model": "likelihood"}],
+            ["[1]", "[2]", "sensor_model=beam", "sensor_model=likelihood"],
+        ),
+    ],
+)
+def test_show_variants_output(capsys, variants, expected_output):
+    """--show-variants prints each variant's number and key=value pairs."""
+
+    @benchmark(variants=variants, num_iterations=1)
+    def fn(ctx):
+        pass
+
+    with pytest.raises(SystemExit):
+        fn(args=["--show-variants"])
+
+    captured = capsys.readouterr()
+    for expected in expected_output:
+        assert expected in captured.out
+
+
+def test_benchmark_variants_flag_filters_runs(variants, tmp_path):
+    """--variants only runs the selected variants."""
+    contexts = []
+
+    @benchmark(variants=variants, num_iterations=1)
+    def fn(ctx):
+        contexts.append(ctx)
+
+    fn(args=["--variants", "1"], base_dir=tmp_path)
+    assert len(contexts) == 1
+    assert contexts[0].variant.sensor_model == variants[0]["sensor_model"]
+    assert contexts[0].variant.num_particles == variants[0]["num_particles"]
+
+
+def test_benchmark_variants_flag_preserves_folder_numbering(variants, tmp_path):
+    """--variants keeps var_N folder names stable relative to the full sweep."""
+    contexts = []
+
+    @benchmark(variants=variants, num_iterations=1)
+    def fn(ctx):
+        contexts.append(ctx)
+
+    fn(args=["--variants", "2"], base_dir=tmp_path)
+    assert contexts[0].paths.variant_dir.name == "var_2"

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -22,27 +22,8 @@ import yaml
 
 from lambkin.common import defaults
 from lambkin.core.ctx.source import Source
-from lambkin.core.decorators.benchmark import _format_elapsed, _parse_options, benchmark
+from lambkin.core.decorators.benchmark import _parse_options, benchmark
 from lambkin.core.decorators.option import option
-
-
-@pytest.mark.parametrize(
-    "seconds,expected",
-    [
-        (0.0, "0.0000s"),
-        (0.0023, "0.0023s"),
-        (59.9999, "59.9999s"),
-        (60.0, "1m 00s"),
-        (103.0, "1m 43s"),
-        (3600.0, "1h 00m 00s"),
-        (3661.0, "1h 01m 01s"),
-        (86400.0, "1d 00h 00m 00s"),
-        (2 * 86400 + 3 * 3600 + 15 * 60 + 7, "2d 03h 15m 07s"),
-    ],
-)
-def test_format_elapsed(seconds, expected):
-    """_format_elapsed formats durations correctly across all time scales."""
-    assert _format_elapsed(seconds) == expected
 
 
 @pytest.fixture
@@ -66,6 +47,8 @@ def test_parse_options_returns_empty_dict_when_no_options():
         "show_options": False,
         "log_output": defaults.LOG_OUTPUT,
         "log_level": defaults.LOG_LEVEL,
+        "show_variants": False,
+        "variants": None,
     }
 
 
@@ -83,6 +66,8 @@ def test_parse_options_returns_defaults_when_no_args():
         "show_options": False,
         "log_output": defaults.LOG_OUTPUT,
         "log_level": defaults.LOG_LEVEL,
+        "show_variants": False,
+        "variants": None,
         "clock_rate": 100.0,
         "sensor_topic": "/scan",
     }
@@ -102,6 +87,8 @@ def test_parse_options_returns_cli_values_when_provided():
         "show_options": False,
         "log_output": defaults.LOG_OUTPUT,
         "log_level": defaults.LOG_LEVEL,
+        "show_variants": False,
+        "variants": None,
         "clock_rate": 50.0,
         "sensor_topic": "/scan",
     }

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the utility functions in lambkin.utils."""
+
+import pytest
+
+from lambkin.utils import format_elapsed_time
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [
+        (0.0, "0.0000s"),
+        (0.0023, "0.0023s"),
+        (59.9999, "59.9999s"),
+        (60.0, "1m 00s"),
+        (103.0, "1m 43s"),
+        (3600.0, "1h 00m 00s"),
+        (3661.0, "1h 01m 01s"),
+        (86400.0, "1d 00h 00m 00s"),
+        (2 * 86400 + 3 * 3600 + 15 * 60 + 7, "2d 03h 15m 07s"),
+    ],
+)
+def test_format_elapsed_time(seconds, expected):
+    """_format_elapsed_time formats durations correctly across all time scales."""
+    assert format_elapsed_time(seconds) == expected


### PR DESCRIPTION
### Proposed changes

This PR adds two new SDK CLI flags to make partial benchmark runs easier to manage when sweeping large parameter spaces.

- `--show-variants` prints all variants with their var_N number and exits, giving users a quick way to discover available indices without opening the script or reading `variants.yaml.`
- `--variants` accepts comma-separated numbers and ranges (e.g. 3:5,42) and limits execution to the selected variants, while keeping folder numbering stable relative to the full sweep.

Logging has also been improved to clearly communicate the scope of each run: total variant and iteration counts are shown upfront, and when --variants is used, the selected subset is reported alongside the full sweep size.

Additionally, `format_elapsed_time` has been extracted to `lambkin/utils/utils.py` as a general-purpose utility with no SDK dependencies.

#### How to Test

```bash
# List all available variants
uv run lambkin examples/beluga/beluga_benchmark.py --show-variants

# Run a subset by number
uv run lambkin examples/beluga/beluga_benchmark.py --variants 1,3

# Run a range plus an individual variant
uv run lambkin examples/beluga/beluga_benchmark.py --variants 1:3,5

# Out-of-range indices are rejected immediately
uv run lambkin examples/beluga/beluga_benchmark.py --variants 1,99
```

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 **Breaking change!** N/A

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments

N/A
