### PR TITLE
Phase 5: Scoped Inputs

### DIFF
--- a/src/lambkin/core/ctx/benchmark_context.py
+++ b/src/lambkin/core/ctx/benchmark_context.py
@@ -41,7 +41,12 @@ class BenchmarkContext:
         source: Source object describing the benchmark script being executed.
         options: Namespaced runtime options (read-only).
         base_dir: Root directory for all benchmark results (read-only).
+        inputs: Resolved benchmark-scoped inputs. ``None`` until set by the
+            registry. Read-only after resolution — raises ``AttributeError``
+            if assigned again.
     """
+
+    scope = "benchmark"
 
     def __init__(
         self,
@@ -63,6 +68,8 @@ class BenchmarkContext:
         self._source = source
         self._options = SimpleNamespace(**options)
         self._base_dir = Path(base_dir)
+        self._inputs: SimpleNamespace | None = None
+        self._inputs_locked: bool = False
 
     @property
     def source(self) -> Source:
@@ -79,6 +86,27 @@ class BenchmarkContext:
         """Root directory for all benchmark results."""
         return self._base_dir
 
+    @property
+    def inputs(self) -> SimpleNamespace | None:
+        """Resolved benchmark-scoped inputs. ``None`` until set by the registry."""
+        return self._inputs
+
+    @inputs.setter
+    def inputs(self, value: SimpleNamespace) -> None:
+        """Set resolved inputs. Read-only after the first assignment.
+
+        Args:
+            value: Resolved benchmark-scoped inputs from
+                ``InputRegistry.resolve``.
+
+        Raises:
+            AttributeError: If called after inputs have already been set.
+        """
+        if self._inputs_locked:
+            raise AttributeError("ctx.inputs is read-only after resolution.")
+        self._inputs = value
+        self._inputs_locked = True
+
     def __enter__(self) -> BenchmarkContext:
         """Create the base output directory on disk.
 
@@ -93,10 +121,12 @@ class BenchmarkContext:
 
     def __repr__(self) -> str:
         """Return a human-readable summary of the BenchmarkContext state."""
+        inputs = vars(self._inputs) if self._inputs is not None else None
         return (
             f"BenchmarkContext(\n"
             f"  source   = {self._source},\n"
             f"  base_dir = {self._base_dir},\n"
-            f"  options  = {vars(self._options)}\n"
+            f"  options  = {vars(self._options)},\n"
+            f"  inputs   = {inputs}\n"
             f")"
         )

--- a/src/lambkin/core/ctx/iteration_context.py
+++ b/src/lambkin/core/ctx/iteration_context.py
@@ -65,7 +65,10 @@ class IterationContext:
             iteration.
         iteration: Zero-based repetition index within this variant.
         paths: Output paths for this (variant, iteration) run.
-        inputs: Namespaced input data resolved before the loop (read-only).
+        inputs: Merged benchmark + variant + iteration inputs. ``None`` until
+            set by the registry via ``ctx.inputs = registry.resolve(ctx)``.
+            Read-only after resolution — raises ``AttributeError`` if
+            assigned again.
         shell: ShellProxy configured for this run. Only available after
             ``__enter__`` on a cache miss; raises ``AttributeError`` on a
             cache hit (``ctx.skipped is True``).
@@ -80,24 +83,23 @@ class IterationContext:
     """
 
     METADATA_FILENAME = "lambkin_metadata.yaml"
+    scope = "iteration"
 
     def __init__(
         self,
         variant_ctx: VariantContext,
         iteration: int,
-        inputs: SimpleNamespace | None = None,
     ) -> None:
         """Initialize an IterationContext from its parent VariantContext.
 
         Args:
             variant_ctx: The parent VariantContext for this run.
             iteration: Zero-based repetition index within this variant.
-            inputs: Resolved input namespace (from
-                ``BenchmarkContext.resolve_inputs``). Defaults to ``None``.
         """
         self._variant_ctx = variant_ctx
         self._iteration = iteration
-        self._inputs = inputs
+        self._inputs: SimpleNamespace | None = None
+        self._inputs_locked: bool = False
 
         self._paths = RunPaths.from_indices(
             variant_ctx.base_dir,
@@ -124,7 +126,6 @@ class IterationContext:
         options: dict[str, Any],
         source: Source,
         base_dir: Path | str,
-        inputs: SimpleNamespace | None = None,
     ) -> IterationContext:
         """Construct an IterationContext directly from raw parameters.
 
@@ -140,7 +141,6 @@ class IterationContext:
             options: Parsed options dict.
             source: Source object describing the benchmark script.
             base_dir: Root directory for all benchmark results.
-            inputs: Optional resolved input namespace.
 
         Returns:
             An ``IterationContext`` ready to be used as a
@@ -152,7 +152,7 @@ class IterationContext:
             variant=variant,
             variant_index=variant_index,
         )
-        return cls(variant_ctx=vctx, iteration=iteration, inputs=inputs)
+        return cls(variant_ctx=vctx, iteration=iteration)
 
     @property
     def iteration(self) -> int:
@@ -166,8 +166,29 @@ class IterationContext:
 
     @property
     def inputs(self) -> SimpleNamespace | None:
-        """Resolved input namespace, or ``None`` if no inputs are registered."""
+        """Merged benchmark + variant + iteration inputs.
+
+        ``None`` until set by the registry. Read-only after resolution —
+        raises ``AttributeError`` if assigned again.
+        """
         return self._inputs
+
+    @inputs.setter
+    def inputs(self, value: SimpleNamespace) -> None:
+        """Merge iteration-scoped inputs with benchmark + variant inputs.
+
+        Args:
+            value: Resolved iteration-scoped inputs from
+                ``InputRegistry.resolve``.
+
+        Raises:
+            AttributeError: If called after inputs have already been set.
+        """
+        if self._inputs_locked:
+            raise AttributeError("ctx.inputs is read-only after resolution.")
+        parent = self._variant_ctx.inputs or SimpleNamespace()
+        self._inputs = SimpleNamespace(**vars(parent), **vars(value))
+        self._inputs_locked = True
 
     @property
     def shell(self) -> ShellProxy:

--- a/src/lambkin/core/ctx/variant_context.py
+++ b/src/lambkin/core/ctx/variant_context.py
@@ -45,7 +45,12 @@ class VariantContext:
             (read-only).
         variant_dir: Output directory for this variant, e.g. ``results/var_1/``
             (read-only). Created on ``__enter__``.
+        inputs: Merged benchmark + variant inputs. ``None`` until set by the
+            registry. Read-only after resolution — raises ``AttributeError``
+            if assigned again.
     """
+
+    scope = "variant"
 
     def __init__(
         self,
@@ -68,6 +73,8 @@ class VariantContext:
         self._variant = SimpleNamespace(**variant)
         self._variant_index = variant_index
         self._variant_dir = benchmark_ctx.base_dir / f"var_{variant_index + 1}"
+        self._inputs: SimpleNamespace | None = None
+        self._inputs_locked: bool = False
 
     @classmethod
     def from_params(
@@ -114,6 +121,27 @@ class VariantContext:
         return self._variant_dir
 
     @property
+    def inputs(self) -> SimpleNamespace | None:
+        """Merged benchmark + variant inputs. ``None`` until set by the registry."""
+        return self._inputs
+
+    @inputs.setter
+    def inputs(self, value: SimpleNamespace) -> None:
+        """Merge variant-scoped inputs with benchmark inputs. Read-only after set.
+
+        Args:
+            value: Resolved variant-scoped inputs from ``InputRegistry.resolve``.
+
+        Raises:
+            AttributeError: If called after inputs have already been set.
+        """
+        if self._inputs_locked:
+            raise AttributeError("ctx.inputs is read-only after resolution.")
+        parent = self._benchmark_ctx.inputs or SimpleNamespace()
+        self._inputs = SimpleNamespace(**vars(parent), **vars(value))
+        self._inputs_locked = True
+
+    @property
     def source(self) -> Source:
         """Source object — delegated to BenchmarkContext."""
         return self._benchmark_ctx.source
@@ -142,10 +170,12 @@ class VariantContext:
 
     def __repr__(self) -> str:
         """Return a human-readable summary of the VariantContext state."""
+        inputs = vars(self._inputs) if self._inputs is not None else None
         return (
             f"VariantContext(\n"
             f"  variant       = {vars(self._variant)},\n"
             f"  variant_index = {self._variant_index},\n"
-            f"  variant_dir   = {self._variant_dir}\n"
+            f"  variant_dir   = {self._variant_dir},\n"
+            f"  inputs        = {inputs}\n"
             f")"
         )

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -353,7 +353,8 @@ def benchmark(variants, num_iterations):
             )
 
         # Expose the input registration hook so users can decorate input providers
-        # with @my_benchmark.input on the returned wrapper.
+        # with @my_benchmark.input (benchmark scope, default) or
+        # @my_benchmark.input(scope="variant") / @my_benchmark.input(scope="iteration").
         wrapper.input = inputs.register
 
         # Expose the output registration hook so users can decorate output providers

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -21,8 +21,8 @@ injects the resulting values into an IterationContext on each
 (variant, iteration) pair.
 
 Input hooks registered via "@nominal.input" are managed by an "InputRegistry"
-instance and resolved once at benchmark scope before the loop starts, injecting
-their return values into ctx.inputs.
+instance and resolved at benchmark, variant, and iteration scope via
+``registry.resolve(ctx)``, injecting their return values into ``ctx.inputs``.
 
 Raises ValueError if variants is empty.
 """
@@ -211,9 +211,12 @@ def benchmark(variants, num_iterations):
 
     Parses CLI options registered by @lambkin.option once before the loop.
     Creates a BenchmarkContext for the entire run, a VariantContext per
-    variant, and an IterationContext per (variant, iteration) pair. Input
-    hooks registered via @nominal.input are resolved once at benchmark scope
-    and injected into each IterationContext as ctx.inputs.
+    variant, and an IterationContext per (variant, iteration) pair.
+
+    Input hooks registered via @nominal.input are managed by an InputRegistry
+    and resolved at three scopes: benchmark (once before the loop), variant
+    (once per variant), and iteration (once per cache-miss iteration).
+    Resolved inputs are merged across scopes and injected into ``ctx.inputs``.
 
     Args:
         variants (list[dict]): Sequence of variant dicts to sweep over. Each
@@ -307,9 +310,9 @@ def benchmark(variants, num_iterations):
                 # always present even if the run is interrupted mid-sweep.
                 _write_variants_yaml(bctx.base_dir, variants)
 
-                # Resolve inputs once at benchmark scope — hooks run before
-                # any variant or iteration context is created.
-                resolved_inputs = inputs.resolve(bctx)
+                # Resolve benchmark-scoped inputs. The registry dispatches on
+                # ctx.scope and the inputs setter handles merging with parent inputs.
+                bctx.inputs = inputs.resolve(bctx)
 
                 # Register the SIGUSR1 handler before any BackgroundProcess
                 # is started inside the benchmark function.
@@ -327,16 +330,19 @@ def benchmark(variants, num_iterations):
                         continue
 
                     with VariantContext(bctx, variant, variant_index) as vctx:
+                        # Resolve variant-scoped inputs, merged with benchmark inputs.
+                        vctx.inputs = inputs.resolve(vctx)
                         for iteration in range(num_iterations):
                             # Log the current run number and
                             # total runs to track progress.
                             current_run += 1
                             logger.info("Benchmark run %d/%d", current_run, total_runs)
-                            with IterationContext(
-                                vctx, iteration, resolved_inputs
-                            ) as ctx:
+                            with IterationContext(vctx, iteration) as ctx:
                                 if ctx.skipped:
                                     continue
+                                # Resolve iteration-scoped inputs, merged with variant
+                                # inputs.
+                                ctx.inputs = inputs.resolve(ctx)
                                 fn(ctx)
             # Run output hooks once at benchmark scope after all iterations complete.
             outputs.run(bctx)

--- a/src/lambkin/core/decorators/input.py
+++ b/src/lambkin/core/decorators/input.py
@@ -14,14 +14,35 @@
 
 """Input decorator for lambkin.
 
-Provides the class "InputRegistry" class, which manages the registration and
-resolution of input hooks for a benchmark function. Hooks are registered via the
-"InputRegistry.register" method and resolved before the benchmark function runs,
-injecting their return values into "ctx.inputs" under the hook's function name.
+Provides the ``InputRegistry`` class, which manages the registration and
+resolution of scoped input hooks for a benchmark function.
+
+Hooks are registered via ``InputRegistry.register`` and resolved against
+the appropriate context by calling ``registry.resolve(ctx)``. The registry
+dispatches on ``ctx.scope`` to determine which hooks to run. Merging with
+parent scope inputs is delegated to the context's ``inputs`` setter.
+
+Hooks can be scoped to one of three lifecycle levels:
+
+- ``"benchmark"`` (default): resolved once before the variant loop, against
+  a ``BenchmarkContext``. Use for inputs that do not depend on the current
+  variant or iteration (e.g. downloading a shared dataset).
+- ``"variant"``: resolved once per variant, against a ``VariantContext``.
+  Use for inputs that depend on ``ctx.variant`` but not ``ctx.iteration``
+  (e.g. selecting a dataset file by sensor model).
+- ``"iteration"``: resolved once per iteration on a cache miss, against an
+  ``IterationContext``. Use for inputs that depend on both ``ctx.variant``
+  and ``ctx.iteration`` (e.g. computing a per-iteration random seed).
+
+Hook names must be unique across all scopes. Registering two hooks with
+the same name — regardless of scope — raises a ``ValueError`` at decoration
+time.
 """
 
 import inspect
 from types import SimpleNamespace
+
+_VALID_SCOPES = frozenset({"benchmark", "variant", "iteration"})
 
 
 def _validate_result(hook_fn, result) -> None:
@@ -37,67 +58,125 @@ def _validate_result(hook_fn, result) -> None:
 
 
 def _validate_hook_signature(hook_fn) -> None:
-    """Validate that the hook function accepts a single 'ctx' parameter."""
+    """Validate that the hook function accepts a single parameter."""
     params = list(inspect.signature(hook_fn).parameters.keys())
-
     if len(params) != 1:
         raise ValueError(f"Hook '{hook_fn.__name__}' must have exactly 1 parameter.")
 
 
 class InputRegistry:
-    """Manages the registration and resolution of input hooks for a benchmark.
+    """Manages the registration and resolution of scoped input hooks.
 
-    Warning:
-        Hooks are resolved with a base context containing dummy variant and
-        iteration values. Accessing Accessing ``ctx.variant`` or
-        ``ctx.iteration`` inside a hook will silently return empty/wrong values.
-        Hooks should only depend on ``ctx.options`` or other stable context fields.
+    Hooks are bucketed by scope (``benchmark``, ``variant``, ``iteration``)
+    and resolved by calling ``registry.resolve(ctx)``, which dispatches on
+    ``ctx.scope``. Merging with parent scope inputs is handled by the
+    context's ``inputs`` setter.
+
+    All hook names must be unique across all scopes.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the InputRegistry."""
-        self._hooks = []
+        self._hooks: dict[str, list] = {
+            "benchmark": [],
+            "variant": [],
+            "iteration": [],
+        }
 
-    def register(self, hook_fn):
-        """Decorator used to register a function as an input provider.
+    def _all_names(self) -> set[str]:
+        """Return all registered hook names across all scopes."""
+        return {h.__name__ for hooks in self._hooks.values() for h in hooks}
 
-        Warning:
-            Do not access ``ctx.variant`` or ``ctx.iteration`` inside the hook;
-            they will contain dummy values at resolve time, leading to silent
-            bugs that are hard to trace.
+    def _do_register(self, fn, scope: str):
+        """Register a single hook function under the given scope.
 
         Args:
-            hook_fn: The function to register as an input provider.
+            fn: The hook function to register.
+            scope: The scope to register the hook under.
 
         Returns:
-            The hook function, unchanged.
+            The hook function unchanged.
 
         Raises:
-            ValueError: If the hook signature is invalid or its name is already
-                registered.
+            ValueError: If the hook signature is invalid or its name conflicts
+                with an already-registered hook in any scope.
         """
-        _validate_hook_signature(hook_fn)
-        existing_names = [h.__name__ for h in self._hooks]
-        if hook_fn.__name__ in existing_names:
+        _validate_hook_signature(fn)
+        if fn.__name__ in self._all_names():
             raise ValueError(
-                f"Hook name conflict: '{hook_fn.__name__}' is already registered."
+                f"Hook name conflict: '{fn.__name__}' is already registered "
+                f"in another scope. Hook names must be unique across all scopes."
             )
-        self._hooks.append(hook_fn)
-        return hook_fn
+        self._hooks[scope].append(fn)
+        return fn
 
-    def resolve(self, ctx):
-        """Resolve all registered input hooks and return a SimpleNamespace snapshot.
+    def register(self, hook_fn=None, *, scope: str = "benchmark"):
+        """Register a function as a scoped input provider.
 
-        Collects all hook results into a local dict first so ctx is never
-        mutated during resolution. The returned snapshot is passed to the
-        Context constructor by the benchmark runner.
+        Supports two calling conventions::
+
+            @nominal.input
+            def dataset(ctx): ...                      # benchmark scope
+
+            @nominal.input(scope="variant")
+            def dataset(ctx): ...                      # variant scope
+
+        Args:
+            hook_fn: The function to register. When the decorator is used
+                without arguments, this is the decorated function. When called
+                with arguments (e.g. ``scope="variant"``), this is ``None``
+                and a decorator is returned instead.
+            scope: Lifecycle scope for this hook. One of ``"benchmark"``,
+                ``"variant"``, or ``"iteration"``. Defaults to ``"benchmark"``.
 
         Returns:
-            SimpleNamespace: A snapshot mapping each hook's function name to
-                its return value.
+            The hook function unchanged (when used as a plain decorator), or
+            a decorator (when called with arguments).
+
+        Raises:
+            ValueError: If ``scope`` is not valid, the hook signature is
+                invalid, or the hook name is already registered in any scope.
         """
+        if scope not in _VALID_SCOPES:
+            raise ValueError(
+                f"Invalid scope {scope!r}. Must be one of: "
+                f"{', '.join(sorted(_VALID_SCOPES))}."
+            )
+        if hook_fn is not None:
+            return self._do_register(hook_fn, scope)
+
+        def decorator(fn):
+            return self._do_register(fn, scope)
+
+        return decorator
+
+    def resolve(self, ctx) -> SimpleNamespace:
+        """Resolve input hooks for the given context scope.
+
+        Dispatches on ``ctx.scope`` to determine which hooks to run and
+        returns the results as a ``SimpleNamespace``. Merging with parent
+        scope inputs is delegated to the context's ``inputs`` setter.
+
+        Args:
+            ctx: A ``BenchmarkContext``, ``VariantContext``, or
+                ``IterationContext`` instance.
+
+        Returns:
+            A ``SimpleNamespace`` containing the inputs resolved at this
+            scope only. The context's ``inputs`` setter handles merging
+            with parent inputs.
+
+        Raises:
+            ValueError: If ``ctx.scope`` is not a recognized scope.
+        """
+        scope = ctx.scope
+        if scope not in _VALID_SCOPES:
+            raise ValueError(
+                f"Unknown context scope {scope!r}. Must be one of: "
+                f"{', '.join(sorted(_VALID_SCOPES))}."
+            )
         resolved = {}
-        for hook in self._hooks:
+        for hook in self._hooks[scope]:
             result = hook(ctx)
             _validate_result(hook, result)
             resolved[hook.__name__] = result

--- a/test/core/test_benchmark.py
+++ b/test/core/test_benchmark.py
@@ -434,3 +434,92 @@ def test_benchmark_no_cache_forces_full_rerun(variants, tmp_path):
     contexts.clear()
     fn(args=["--no-cache"], base_dir=tmp_path)
     assert len(contexts) == len(variants)
+
+
+def test_benchmark_scoped_hook_called_once_before_loop(variants, tmp_path):
+    """Benchmark-scoped input hooks are resolved once before any variant runs."""
+    call_count = 0
+    seen_inputs = []
+
+    @benchmark(variants=variants, num_iterations=2)
+    def fn(ctx):
+        seen_inputs.append(ctx.inputs.shared)
+
+    @fn.input(scope="benchmark")
+    def shared(ctx):
+        nonlocal call_count
+        call_count += 1
+        return "shared.mcap"
+
+    fn(base_dir=tmp_path)
+
+    # Hook called exactly once regardless of variants and iterations
+    assert call_count == 1
+
+    # All iterations see the same benchmark-scoped input
+    assert all(v == "shared.mcap" for v in seen_inputs)
+    assert len(seen_inputs) == len(variants) * 2
+
+
+def test_benchmark_variant_scoped_hook_called_once_per_variant(variants, tmp_path):
+    """Variant-scoped input hooks are resolved once per variant."""
+    call_count = 0
+
+    @benchmark(variants=variants, num_iterations=3)
+    def fn(ctx):
+        pass
+
+    @fn.input(scope="variant")
+    def dataset(ctx):
+        nonlocal call_count
+        call_count += 1
+        return f"{ctx.variant.sensor_model}.mcap"
+
+    fn(base_dir=tmp_path)
+    assert call_count == len(variants)
+
+
+def test_benchmark_iteration_scoped_hook_not_called_on_cache_hit(tmp_path):
+    """Iteration-scoped hooks are not resolved when iteration is a cache hit."""
+    call_count = 0
+
+    @benchmark(variants=[{"x": 1}], num_iterations=1)
+    def fn(ctx):
+        pass
+
+    @fn.input(scope="iteration")
+    def seed(ctx):
+        nonlocal call_count
+        call_count += 1
+        return f"seed_{ctx.iteration}"
+
+    # First run — cache miss, hook is called
+    fn(base_dir=tmp_path)
+    assert call_count == 1
+
+    # Second run — cache hit, iteration-scoped hook not called
+    call_count = 0
+    fn(base_dir=tmp_path)
+    assert call_count == 0
+
+
+def test_benchmark_partial_restart_only_reruns_failed_iterations(tmp_path):
+    """Only failed iterations rerun on a partial restart."""
+    calls = []
+    should_fail = [True]
+
+    @benchmark(variants=[{"x": 1}, {"x": 2}], num_iterations=1)
+    def fn(ctx):
+        calls.append(ctx.variant_index)
+        if ctx.variant_index == 1 and should_fail[0]:
+            raise RuntimeError("simulated failure")
+
+    with pytest.raises(RuntimeError):
+        fn(base_dir=tmp_path)
+
+    assert calls == [0, 1]
+
+    calls.clear()
+    should_fail[0] = False
+    fn(base_dir=tmp_path)
+    assert calls == [1]

--- a/test/core/test_context.py
+++ b/test/core/test_context.py
@@ -182,7 +182,7 @@ class TestIterationContext:
             assert ctx.source is source
 
     def test_inputs_defaults_to_none(self, vctx):
-        """Inputs is None when not provided."""
+        """ctx.inputs is None before registry.resolve is called."""
         with IterationContext(variant_ctx=vctx, iteration=0) as ctx:
             assert ctx.inputs is None
 

--- a/test/core/test_input.py
+++ b/test/core/test_input.py
@@ -14,9 +14,15 @@
 
 """Unit tests for the input decorator in lambkin.core.decorators."""
 
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 
-from lambkin.core.ctx import IterationContext
+from lambkin.core.ctx.benchmark_context import BenchmarkContext
+from lambkin.core.ctx.iteration_context import IterationContext
+from lambkin.core.ctx.source import Source
+from lambkin.core.ctx.variant_context import VariantContext
 from lambkin.core.decorators.benchmark import benchmark
 from lambkin.core.decorators.input import InputRegistry
 
@@ -29,6 +35,43 @@ def variant():
     ]
 
 
+@pytest.fixture
+def base_options():
+    """Minimal dry-run options."""
+    return {
+        "dry_run": True,
+        "no_cache": False,
+        "log_output": "file",
+        "log_level": "info",
+    }
+
+
+@pytest.fixture
+def source(tmp_path):
+    """A Source pointing to this test file."""
+    return Source(path=Path(__file__))
+
+
+@pytest.fixture
+def bctx(source, base_options, tmp_path):
+    """An entered BenchmarkContext."""
+    with BenchmarkContext(
+        source=source, options=base_options, base_dir=tmp_path
+    ) as ctx:
+        yield ctx
+
+
+@pytest.fixture
+def vctx(bctx):
+    """An entered VariantContext."""
+    with VariantContext(
+        benchmark_ctx=bctx,
+        variant={"sensor_model": "beam", "num_particles": 10},
+        variant_index=0,
+    ) as ctx:
+        yield ctx
+
+
 def test_register_returns_original_function():
     """register() returns the original function unchanged."""
     registry = InputRegistry()
@@ -39,21 +82,30 @@ def test_register_returns_original_function():
     assert registry.register(dataset) is dataset
 
 
-def test_registered_hook_name_is_preserved():
+def test_register_with_scope_returns_original_function():
+    """register(scope=...) also returns the original function unchanged."""
+    registry = InputRegistry()
+
+    def dataset(ctx):
+        return "data.mcap"
+
+    assert registry.register(scope="variant")(dataset) is dataset
+
+
+def test_registered_hook_name_is_preserved(bctx):
     """The ctx.inputs attribute name is the hook's __name__."""
     registry = InputRegistry()
-    ctx = IterationContext.__new__(IterationContext)
 
     def my_dataset(ctx):
         return "some_value"
 
     registry.register(my_dataset)
-    result = registry.resolve(ctx)
+    result = registry.resolve(bctx)
     assert hasattr(result, "my_dataset")
 
 
 def test_hook_with_no_parameters_raises():
-    """A hook with no parameters raises ValueError at resolve time."""
+    """A hook with no parameters raises ValueError at registration time."""
     registry = InputRegistry()
 
     def bad_hook():
@@ -64,7 +116,7 @@ def test_hook_with_no_parameters_raises():
 
 
 def test_hook_with_extra_parameters_raises():
-    """A hook with more than 1 parameter raises ValueError at resolve time."""
+    """A hook with more than 1 parameter raises ValueError at registration time."""
     registry = InputRegistry()
 
     def bad_hook(ctx, extra):
@@ -74,56 +126,182 @@ def test_hook_with_extra_parameters_raises():
         registry.register(bad_hook)
 
 
-def test_hook_returning_none_raises():
+def test_name_collision_across_scopes_raises():
+    """Registering two hooks with the same name in different scopes raises."""
+    registry = InputRegistry()
+
+    def dataset(ctx):
+        return "benchmark.mcap"
+
+    registry.register(dataset)
+
+    def dataset(ctx):  # noqa: F811
+        return "variant.mcap"
+
+    with pytest.raises(ValueError, match="Hook name conflict"):
+        registry.register(dataset, scope="variant")
+
+
+def test_invalid_scope_raises():
+    """Registering a hook with an invalid scope raises ValueError."""
+    registry = InputRegistry()
+
+    def dataset(ctx):
+        return "data.mcap"
+
+    with pytest.raises(ValueError, match="Invalid scope"):
+        registry.register(dataset, scope="invalid")
+
+
+def test_hook_returning_none_raises(bctx):
     """A hook that returns None raises ValueError."""
     registry = InputRegistry()
-    ctx = IterationContext.__new__(IterationContext)
 
     def dataset(ctx):
         return None
 
     registry.register(dataset)
     with pytest.raises(ValueError, match="None"):
-        registry.resolve(ctx)
+        registry.resolve(bctx)
 
 
-def test_hook_with_no_return_raises():
+def test_hook_with_no_return_raises(bctx):
     """A hook with no return statement raises ValueError."""
     registry = InputRegistry()
-    ctx = IterationContext.__new__(IterationContext)
 
     def dataset(ctx):
         pass
 
     registry.register(dataset)
     with pytest.raises(ValueError, match="None"):
-        registry.resolve(ctx)
+        registry.resolve(bctx)
 
 
-def test_hook_returning_empty_string_raises():
+def test_hook_returning_empty_string_raises(bctx):
     """A hook that returns an empty string raises ValueError."""
     registry = InputRegistry()
-    ctx = IterationContext.__new__(IterationContext)
 
     def dataset(ctx):
         return ""
 
     registry.register(dataset)
     with pytest.raises(ValueError, match="empty"):
-        registry.resolve(ctx)
+        registry.resolve(bctx)
 
 
-def test_hook_returning_blank_string_raises():
+def test_hook_returning_blank_string_raises(bctx):
     """A hook that returns a whitespace-only string raises ValueError."""
     registry = InputRegistry()
-    ctx = IterationContext.__new__(IterationContext)
 
     def dataset(ctx):
         return "   "
 
     registry.register(dataset)
     with pytest.raises(ValueError, match="empty"):
+        registry.resolve(bctx)
+
+
+def test_benchmark_scoped_hook_receives_benchmark_context(bctx):
+    """Benchmark-scoped hook receives a BenchmarkContext."""
+    registry = InputRegistry()
+    received = []
+
+    def dataset(ctx):
+        received.append(ctx)
+        return "data.mcap"
+
+    registry.register(dataset)
+    registry.resolve(bctx)
+    assert received[0] is bctx
+
+
+def test_variant_scoped_hook_receives_variant_context(vctx):
+    """Variant-scoped hook receives a VariantContext with correct variant."""
+    registry = InputRegistry()
+    received = []
+
+    def dataset(ctx):
+        received.append(ctx)
+        return "data.mcap"
+
+    registry.register(dataset, scope="variant")
+    registry.resolve(vctx)
+    assert received[0] is vctx
+    assert received[0].variant.sensor_model == "beam"
+
+
+def test_iteration_scoped_hook_receives_iteration_context(vctx):
+    """Iteration-scoped hook receives an IterationContext."""
+    registry = InputRegistry()
+    received = []
+
+    def seed(ctx):
+        received.append(ctx)
+        return f"seed_{ctx.iteration}"
+
+    registry.register(seed, scope="iteration")
+
+    with IterationContext(variant_ctx=vctx, iteration=2) as ctx:
         registry.resolve(ctx)
+    assert isinstance(received[0], IterationContext)
+    assert received[0].iteration == 2
+
+
+def test_variant_inputs_merged_with_benchmark_inputs(bctx, vctx):
+    """Variant-scoped inputs are merged with benchmark-scoped inputs."""
+    registry = InputRegistry()
+
+    def reference(ctx):
+        return "ref.tum"
+
+    def dataset(ctx):
+        return f"{ctx.variant.sensor_model}.mcap"
+
+    registry.register(reference)
+    registry.register(dataset, scope="variant")
+
+    bctx.inputs = registry.resolve(bctx)
+    vctx.inputs = registry.resolve(vctx)
+
+    assert vctx.inputs.reference == "ref.tum"
+    assert vctx.inputs.dataset == "beam.mcap"
+
+
+def test_iteration_inputs_merged_with_parent_inputs(bctx, vctx):
+    """Iteration-scoped inputs are merged with benchmark + variant inputs."""
+    registry = InputRegistry()
+
+    it = 3
+    multiplier = 43
+
+    def reference(ctx):
+        return "ref.tum"
+
+    def dataset(ctx):
+        return f"{ctx.variant.sensor_model}.mcap"
+
+    def seed(ctx):
+        return ctx.iteration * multiplier
+
+    registry.register(reference)
+    registry.register(dataset, scope="variant")
+    registry.register(seed, scope="iteration")
+
+    bctx.inputs = registry.resolve(bctx)
+    vctx.inputs = registry.resolve(vctx)
+
+    with IterationContext(variant_ctx=vctx, iteration=it) as ctx:
+        ctx.inputs = registry.resolve(ctx)
+        assert ctx.inputs.reference == "ref.tum"
+        assert ctx.inputs.dataset == "beam.mcap"
+        assert ctx.inputs.seed == it * multiplier
+
+
+def test_inputs_locked_after_resolution(bctx):
+    """ctx.inputs raises AttributeError if assigned again after resolution."""
+    bctx.inputs = SimpleNamespace(reference="ref.tum")
+    with pytest.raises(AttributeError, match="read-only after resolution"):
+        bctx.inputs = SimpleNamespace(reference="other.tum")
 
 
 def test_ctx_inputs_populated_before_fn_runs(variant, tmp_path):
@@ -183,8 +361,43 @@ def test_input_hook_called_once_regardless_of_variants_and_iterations(tmp_path):
         return "path/to/dataset.mcap"
 
     nominal(base_dir=tmp_path)
-
     assert call_count == 1
+
+
+def test_variant_scoped_hook_sees_correct_variant(tmp_path):
+    """Variant-scoped hook receives the correct variant for each run."""
+    seen = []
+    variants = [
+        {"sensor_model": "beam"},
+        {"sensor_model": "likelihood"},
+    ]
+
+    @benchmark(variants=variants, num_iterations=1)
+    def nominal(ctx):
+        seen.append(ctx.inputs.dataset)
+
+    @nominal.input(scope="variant")
+    def dataset(ctx):
+        return f"{ctx.variant.sensor_model}.mcap"
+
+    nominal(base_dir=tmp_path)
+    assert seen == ["beam.mcap", "likelihood.mcap"]
+
+
+def test_iteration_scoped_hook_sees_correct_iteration(tmp_path):
+    """Iteration-scoped hook receives the correct iteration index."""
+    seen = []
+
+    @benchmark(variants=[{"x": 1}], num_iterations=3)
+    def nominal(ctx):
+        seen.append(ctx.inputs.seed)
+
+    @nominal.input(scope="iteration")
+    def seed(ctx):
+        return ctx.iteration
+
+    nominal(base_dir=tmp_path)
+    assert seen == [0, 1, 2]
 
 
 def test_input_hooks_called_even_when_all_iterations_cached(variant, tmp_path):

--- a/test/core/test_input.py
+++ b/test/core/test_input.py
@@ -304,6 +304,21 @@ def test_inputs_locked_after_resolution(bctx):
         bctx.inputs = SimpleNamespace(reference="other.tum")
 
 
+def test_variant_context_inputs_locked_after_resolution(vctx):
+    """vctx.inputs raises AttributeError if assigned again after resolution."""
+    vctx.inputs = SimpleNamespace(dataset="data.mcap")
+    with pytest.raises(AttributeError, match="read-only after resolution"):
+        vctx.inputs = SimpleNamespace(dataset="other.mcap")
+
+
+def test_iteration_context_inputs_locked_after_resolution(vctx):
+    """ctx.inputs raises AttributeError if assigned again after resolution."""
+    with IterationContext(variant_ctx=vctx, iteration=0) as ctx:
+        ctx.inputs = SimpleNamespace(seed="seed_0")
+        with pytest.raises(AttributeError, match="read-only after resolution"):
+            ctx.inputs = SimpleNamespace(seed="seed_1")
+
+
 def test_ctx_inputs_populated_before_fn_runs(variant, tmp_path):
     """ctx.inputs.dataset is available inside the benchmark function after resolve."""
     seen = []

--- a/test/integration/test_scoped_inputs.py
+++ b/test/integration/test_scoped_inputs.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test: scoped input hooks resolve at the correct lifecycle level."""
+
+from lambkin.core.decorators.benchmark import benchmark
+
+
+def test_scoped_inputs_resolve_at_correct_lifecycle(tmp_path):
+    """Benchmark, variant, and iteration inputs resolve at the right scope.
+
+    - Benchmark-scoped hooks run once before the loop.
+    - Variant-scoped hooks run once per variant, with access to ctx.variant.
+    - Iteration-scoped hooks run once per cache-miss iteration.
+    All three scopes are merged and accessible via ctx.inputs inside fn(ctx).
+    """
+    benchmark_calls = []
+    variant_calls = []
+    iteration_calls = []
+    seen_inputs = []
+
+    variants = [
+        {"sensor_model": "beam", "dataset": "dataset1.mcap"},
+        {"sensor_model": "likelihood", "dataset": "dataset2.mcap"},
+    ]
+    num_iterations = 2
+
+    @benchmark(variants=variants, num_iterations=num_iterations)
+    def nominal(ctx):
+        seen_inputs.append((
+            ctx.variant.sensor_model,
+            ctx.inputs.shared,
+            ctx.inputs.variant_dataset,
+            ctx.inputs.seed,
+        ))
+
+    @nominal.input
+    def shared(ctx):
+        benchmark_calls.append(1)
+        return "ground_truth.tum"
+
+    @nominal.input(scope="variant")
+    def variant_dataset(ctx):
+        variant_calls.append(ctx.variant.sensor_model)
+        return ctx.variant.dataset
+
+    @nominal.input(scope="iteration")
+    def seed(ctx):
+        iteration_calls.append(ctx.iteration)
+        return f"seed_{ctx.iteration}"
+
+    nominal(args=["--dry-run"], base_dir=tmp_path)
+
+    # Benchmark scope — called exactly once before the loop
+    assert len(benchmark_calls) == 1
+
+    # Variant scope — called once per variant, with correct variant each time
+    assert len(variant_calls) == len(variants)
+    assert variant_calls == ["beam", "likelihood"]
+
+    # Iteration scope — called once per (variant, iteration) pair
+    assert len(iteration_calls) == len(variants) * num_iterations
+
+    # All three scopes merged correctly and accessible inside fn(ctx)
+    assert seen_inputs[0] == ("beam", "ground_truth.tum", "dataset1.mcap", "seed_0")
+    assert seen_inputs[1] == ("beam", "ground_truth.tum", "dataset1.mcap", "seed_1")
+    assert seen_inputs[2] == (
+        "likelihood",
+        "ground_truth.tum",
+        "dataset2.mcap",
+        "seed_0",
+    )
+    assert seen_inputs[3] == (
+        "likelihood",
+        "ground_truth.tum",
+        "dataset2.mcap",
+        "seed_1",
+    )


### PR DESCRIPTION
### Proposed changes

Implements scoped input hooks, allowing users to register input providers at three lifecycle levels: benchmark, variant, and iteration. This gives benchmarks access to the full context at the right time — variant-scoped hooks can read `ctx.variant`, and iteration-scoped hooks can read `ctx.iteration` and the full iteration context.

Key implementation details:

- `@nominal.input (default, scope="benchmark")` preserves existing behavior — resolved once before the loop, backward compatible with all existing benchmarks.
- `@nominal.input(scope="variant")` resolves once per variant, with access to `ctx.variant`.
- `@nominal.input(scope="iteration")` resolves once per cache-miss iteration, with access to `ctx.iteration` and the full iteration context.
- `registry.resolve(ctx)` dispatches on `ctx.scope` — the registry depends on contexts, not the other way around.
- Merging across scopes is delegated to each context's `inputs` setter, keeping merge logic co-located with the context that owns the parent reference.
- `ctx.inputs` is locked after the first assignment — assigning again raises `AttributeError`, preventing user code from accidentally overwriting resolved inputs inside the benchmark function.
- Hook names must be unique across all scopes — name collisions raise `ValueError` at registration time.

Added and updated tests to cover the new logic.

#### How to Test

Write a small benchmark script exercising all three scopes:

```py
import lambkin

@lambkin.benchmark(
    variants=lambkin.common.named_product(
        sensor_model=["beam", "likelihood"],
        dataset=["dataset1.mcap", "dataset2.mcap"],
    ),
    num_iterations=2,
)
def nominal(ctx):
    lambkin.logger.info(
        "sensor=%s iter=%d shared=%s variant_dataset=%s seed=%s",
        ctx.variant.sensor_model, ctx.iteration,
        ctx.inputs.shared, ctx.inputs.variant_dataset, ctx.inputs.seed,
    )

@nominal.input(scope="benchmark")
def shared(ctx):
    lambkin.logger.info("[benchmark] resolving shared")
    return "shared.mcap"

@nominal.input(scope="variant")
def variant_dataset(ctx):
    lambkin.logger.info("[variant] resolving for %s", ctx.variant.sensor_model)
    return ctx.variant.dataset

@nominal.input(scope="iteration")
def seed(ctx):
    lambkin.logger.info("[iteration] resolving for iter=%d", ctx.iteration)
    return f"seed_{ctx.iteration}"


if __name__ == "__main__":
    nominal()
```

Run with:

```bash
uv run lambkin my_benchmark.py --dry-run
```

Verify in the logs that `[benchmark]` appears once, `[variant]` appears once per variant, and `[iteration]` appears once per iteration.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 **No Breaking change!**

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments

N/A