### PR TITLE
Phase 5: Add non-strict mypy check as part of pre-commit and solve current issues in src/

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,12 @@ repos:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: uv run mypy
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,13 @@ dev = [
     "ruff>=0.15.0",
     "mypy>=1.19.1",
     "pytest>=8.0",
+    "types-pyyaml>=6.0.12.20260518",
 ]
 
 [tool.mypy]
 strict = true
 python_version = "3.10"
+files = ["src"]
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dev = [
 ]
 
 [tool.mypy]
-strict = true
+# TODO(xaru8145): set sctrict to true
+strict = false
 python_version = "3.10"
 files = ["src"]
 

--- a/src/lambkin/cli.py
+++ b/src/lambkin/cli.py
@@ -32,6 +32,8 @@ import sys
 import termios
 import uuid
 from pathlib import Path
+from types import FrameType
+from typing import Any
 
 import click
 from click.formatting import HelpFormatter
@@ -79,7 +81,7 @@ class LambkinCommand(click.Command):
             formatter.write_text("Run 'lambkin SCRIPT --show-options' to list them.")
 
 
-def _save_terminal_state() -> list | None:
+def _save_terminal_state() -> list[Any] | None:
     """Save the current terminal state for later restoration.
 
     Reads the terminal attributes from stdin using termios. If stdin is not
@@ -95,7 +97,7 @@ def _save_terminal_state() -> list | None:
     return None
 
 
-def _restore_terminal_state(state: list | None) -> None:
+def _restore_terminal_state(state: list[Any] | None) -> None:
     """Restore stdin terminal attributes to a previously saved state.
 
     If state is None or stdin is no longer a terminal, this is a no-op.
@@ -114,7 +116,7 @@ def _restore_terminal_state(state: list | None) -> None:
 )
 @click.argument("script", type=click.Path(exists=True, path_type=Path))
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
-def main(script: Path, args: tuple, log_level: str) -> None:
+def main(script: Path, args: tuple[str, ...], log_level: str) -> None:
     """Launch a lambkin benchmark script.
 
     Executes ``script`` with the same Python interpreter inside a dedicated
@@ -156,7 +158,7 @@ def main(script: Path, args: tuple, log_level: str) -> None:
     # killed. We restore it after the script exits.
     terminal_state = _save_terminal_state()
 
-    def _handle_sigint(signum, frame):
+    def _handle_sigint(signum: int, frame: FrameType | None) -> None:
         raise KeyboardInterrupt
 
     signal.signal(signal.SIGINT, _handle_sigint)

--- a/src/lambkin/common/named_product.py
+++ b/src/lambkin/common/named_product.py
@@ -19,9 +19,10 @@ Used to define benchmark configurations in a readable and structured way.
 """
 
 import itertools
+from typing import Any
 
 
-def named_product(**parameters):
+def named_product(**parameters: list[Any]) -> list[dict[str, Any]]:
     """Generate all combinations of named parameters.
 
     Takes parameters where each value is a list of options

--- a/src/lambkin/common/signals.py
+++ b/src/lambkin/common/signals.py
@@ -13,13 +13,17 @@ handled there.
 import os
 import signal
 import threading
+from collections.abc import Callable
+from types import FrameType
 
 from lambkin.common.exceptions import LambkinSIGUSR1Interrupt
 
 sigusr1_pending = threading.Event()
 
+SignalHandler = signal.Handlers | Callable[[int, FrameType | None], None] | int | None
 
-def _make_handler(previous):
+
+def _make_handler(previous: SignalHandler) -> Callable[[int, FrameType | None], None]:
     """Create a SIGUSR1 handler that raises LambkinSIGUSR1Interrupt if lambkin sent it.
 
     Args:
@@ -30,7 +34,7 @@ def _make_handler(previous):
         A signal handler function.
     """
 
-    def _handle_sigusr1(signum, frame):
+    def _handle_sigusr1(signum: int, frame: FrameType | None) -> None:
         """Handle SIGUSR1 by interrupting proc.wait() or forwarding the signal.
 
         Raises LambkinSIGUSR1Interrupt if lambkin set the pending flag, which
@@ -58,7 +62,7 @@ def _make_handler(previous):
     return _handle_sigusr1
 
 
-def setup():
+def setup() -> None:
     """Register the SIGUSR1 handler for the benchmark script process.
 
     Must be called once before any BackgroundProcess is started. Registered

--- a/src/lambkin/core/ctx/benchmark_context.py
+++ b/src/lambkin/core/ctx/benchmark_context.py
@@ -25,7 +25,7 @@ before the variant/iteration loops.
 from __future__ import annotations
 
 from pathlib import Path
-from types import SimpleNamespace
+from types import SimpleNamespace, TracebackType
 from typing import Any
 
 from .source import Source
@@ -116,7 +116,12 @@ class BenchmarkContext:
         self._base_dir.mkdir(parents=True, exist_ok=True)
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """No-op — BenchmarkContext holds no resources that need cleanup."""
 
     def __repr__(self) -> str:

--- a/src/lambkin/core/ctx/iteration_context.py
+++ b/src/lambkin/core/ctx/iteration_context.py
@@ -27,7 +27,7 @@ import datetime
 import logging
 import shutil
 from pathlib import Path
-from types import SimpleNamespace
+from types import SimpleNamespace, TracebackType
 from typing import Any
 
 import yaml
@@ -279,7 +279,12 @@ class IterationContext:
         self._write_metadata()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Finalize the iteration, writing completion metadata and cleaning up.
 
         If skipped, exits immediately. Otherwise writes ``completed_at`` to

--- a/src/lambkin/core/ctx/iteration_context.py
+++ b/src/lambkin/core/ctx/iteration_context.py
@@ -114,7 +114,7 @@ class IterationContext:
 
         self._shell: ShellProxy | None = None
         self._skipped: bool = False
-        self._iteration_cgroup = None
+        self._iteration_cgroup: Path | None = None
         self._started_at: str | None = None
 
     @classmethod

--- a/src/lambkin/core/ctx/variant_context.py
+++ b/src/lambkin/core/ctx/variant_context.py
@@ -25,7 +25,7 @@ inside the variant loop.
 from __future__ import annotations
 
 from pathlib import Path
-from types import SimpleNamespace
+from types import SimpleNamespace, TracebackType
 from typing import Any
 
 from .benchmark_context import BenchmarkContext
@@ -165,7 +165,12 @@ class VariantContext:
         self._variant_dir.mkdir(parents=True, exist_ok=True)
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """No-op — VariantContext holds no resources that need cleanup."""
 
     def __repr__(self) -> str:

--- a/src/lambkin/core/decorators/benchmark.py
+++ b/src/lambkin/core/decorators/benchmark.py
@@ -129,7 +129,7 @@ def _parse_index_list(raw: str, label: str, max_value: int | None = None) -> set
         click.BadParameter: If any token is not a positive integer or a valid
             start:end range, or within the allowed range.
     """
-    result = set()
+    result: set[int] = set()
     for token in raw.split(","):
         token = token.strip()
         # Check if the token is a range (contains ":") or a single number, and parse

--- a/src/lambkin/core/process/background.py
+++ b/src/lambkin/core/process/background.py
@@ -28,7 +28,8 @@ import signal
 import subprocess
 import threading
 from pathlib import Path
-from typing import Any
+from types import TracebackType
+from typing import IO, Any
 
 from lambkin.common import defaults, exceptions, signals
 from lambkin.core.process.cgroup import kill_cgroup, make_process_cgroup, remove_cgroup
@@ -54,9 +55,9 @@ class BackgroundProcess:
         iteration_cgroup: Path,
         cwd: Path | None = None,
         dry_run: bool = False,
-        env: dict | None = None,
-        stdout=None,
-        stderr=None,
+        env: dict[str, str] | None = None,
+        stdout: IO[str] | None = None,
+        stderr: IO[str] | None = None,
     ) -> None:
         """Initialize the BackgroundProcess.
 
@@ -75,7 +76,7 @@ class BackgroundProcess:
         self._iteration_cgroup = iteration_cgroup
         self._dry_run = dry_run
         self._cgroup: Path | None = None
-        self._proc: subprocess.Popen | None = None
+        self._proc: subprocess.Popen[bytes] | None = None
         self._monitor: threading.Thread | None = None
         self._died_unexpectedly: bool = False
         self._exiting: threading.Event = threading.Event()
@@ -89,6 +90,7 @@ class BackgroundProcess:
 
         Runs in the child process after fork() but before exec().
         """
+        assert self._cgroup is not None
         (self._cgroup / "cgroup.procs").write_text(str(os.getpid()))
 
     def _monitor_process(self) -> None:
@@ -99,6 +101,7 @@ class BackgroundProcess:
         any blocking foreground process. BackgroundProcess.__exit__ is
         responsible for raising LambkinProcessDiedUnexpectedlyError.
         """
+        assert self._proc is not None
         self._proc.wait()
         if not self._exiting.is_set():
             self._died_unexpectedly = True
@@ -134,7 +137,12 @@ class BackgroundProcess:
         self._monitor.start()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Stop the background process and clean up its cgroup.
 
         Args:
@@ -154,6 +162,7 @@ class BackgroundProcess:
             self._stderr.close()
         self._exiting.set()
 
+        assert self._cgroup is not None
         kill_cgroup(self._cgroup, grace_period=defaults.SIGTERM_GRACE_PERIOD)
 
         if self._monitor is not None:
@@ -161,6 +170,7 @@ class BackgroundProcess:
 
         remove_cgroup(self._cgroup)
 
+        assert self._proc is not None
         if exc_type is None and self._died_unexpectedly:
             returncode = self._proc.poll()
             raise exceptions.LambkinProcessDiedUnexpectedlyError(
@@ -179,6 +189,9 @@ def background(proxy: CommandProxy, *args: Any, **kwargs: Any) -> BackgroundProc
     Returns:
         BackgroundProcess: A context manager that runs the command in the background.
 
+    Raises:
+        ValueError: If the proxy has no cgroup set.
+
     Example:
         with background(ctx.shell.ros2.bag.record, "-O", "output.mcap", "-a"):
         ...
@@ -187,9 +200,12 @@ def background(proxy: CommandProxy, *args: Any, **kwargs: Any) -> BackgroundProc
     argv = proxy.build_argv(*args, **kwargs)
     env = proxy.build_env()
     stdout, stderr = proxy.open_streams(per_call_log_output)
+    cgroup = proxy.get_cgroup()
+    if cgroup is None:
+        raise ValueError("background() requires a proxy with a cgroup set.")
     return BackgroundProcess(
         argv=argv,
-        iteration_cgroup=proxy.get_cgroup(),
+        iteration_cgroup=cgroup,
         cwd=proxy.get_cwd(),
         dry_run=proxy.get_dry_run(),
         env=env,

--- a/src/lambkin/core/shell/proxy.py
+++ b/src/lambkin/core/shell/proxy.py
@@ -298,32 +298,17 @@ class CommandProxy:
         if self._dry_run:
             logger.debug("[DRY RUN] %s", shlex.join(argv))
             return subprocess.CompletedProcess(argv, returncode=0)
+
+        stdout, stderr = None, None
+        proc: subprocess.Popen[bytes] | None = None
+        interrupted = False
+
         try:
             stdout, stderr = self.open_streams(per_call_log_output)
-            proc = None
-            interrupted = False
-            try:
-                proc = self._make_popen(argv, stdout, stderr)
-                proc.wait()
-            except exceptions.LambkinSIGUSR1Interrupt:
-                interrupted = True
-            finally:
-                if proc is not None and proc.poll() is None:
-                    proc.kill()
-                    proc.wait()
-                if stdout:
-                    stdout.close()
-                if stderr:
-                    stderr.close()
-            if not interrupted and proc.returncode != 0:
-                raise CommandError(
-                    argv,
-                    f"Command {shlex.join(argv)!r} failed with return code"
-                    f" {proc.returncode}.",
-                    returncode=proc.returncode,
-                )
-            if not interrupted:
-                return subprocess.CompletedProcess(argv, returncode=proc.returncode)
+            proc = self._make_popen(argv, stdout, stderr)
+            proc.wait()
+        except exceptions.LambkinSIGUSR1Interrupt:
+            interrupted = True
         # FileNotFoundError and PermissionError must come before OSError,
         # as they are subclasses of it. Order matters here.
         except FileNotFoundError:
@@ -343,6 +328,29 @@ class CommandProxy:
                 argv,
                 f"OS error while starting {argv[0]!r}: {e}.",
             ) from e
+        finally:
+            if proc is not None and proc.poll() is None:
+                proc.kill()
+                proc.wait()
+            if stdout:
+                stdout.close()
+            if stderr:
+                stderr.close()
+
+        if interrupted:
+            # dummy return — never observed, background.__exit__ raises
+            # LambkinProcessDiedUnexpectedlyError immediately after
+            return subprocess.CompletedProcess(argv, returncode=-1)
+
+        assert proc is not None
+        if not interrupted and proc.returncode != 0:
+            raise CommandError(
+                argv,
+                f"Command {shlex.join(argv)!r} failed with return code"
+                f" {proc.returncode}.",
+                returncode=proc.returncode,
+            )
+        return subprocess.CompletedProcess(argv, returncode=proc.returncode)
 
 
 class ShellProxy:

--- a/uv.lock
+++ b/uv.lock
@@ -448,6 +448,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -462,6 +463,7 @@ dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.15.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
 ]
 
 [[package]]
@@ -1777,6 +1779,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Proposed changes

Prior to this change, `mypy` was configured in `pyproject.toml` but never enforced — it was neither wired into the `pre-commit hooks` nor gated in CI. As a result, type errors had accumulated silently in `src/` over time despite the configuration being present. 

This PR adds `mypy` to `.pre-commit-config.yaml`, making it part of the standard pre-commit pipeline which is already run in CI via `action-pre-commit-uv`. 

Scoping decisions:

- Strict mode is intentionally disabled for now — strictness will be increased incrementally in future phases.
- `tests/` is excluded from the mypy scope to avoid noise and keep the focus on source code.
- With these two decisions, all type errors present in `src/` under non-strict mode have been fixed as part of this PR.

Why a `local` hook instead of `mirrors-mypy`?

- `mirrors-mypy` runs in an isolated environment and cannot see the project's `uv`-managed virtualenv.
- Dependencies would need to be duplicated in `additional_dependencies`, creating a maintenance burden.
- A local hook using `uv run mypy` runs inside the project's own virtualenv with all dependencies available.

Why `pass_filenames: false`?

- Pre-commit by default passes only staged files to the hook, causing mypy to check files in isolation.
- This would miss cross-file type errors
- With `pass_filenames: false`, mypy uses its own file discovery via `pyproject.toml` and checks the full `src`/ tree on every run

#### How to Test

Run mypy:

```
uv sync
uv run mypy
```

Ensure all tests pass:

```
uv run pytest
```

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 **No Breaking change!**

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments

_Anything worth mentioning to the reviewers._
