### PR TITLE
Phase 5: Fix flaky test due to SIGUSR1 race condition in BackgroundProcess

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -1,0 +1,31 @@
+name: stress
+
+on:
+  workflow_dispatch:
+  schedule:
+    # TODO: remove schedule once stress test has been stable for ~2 weeks
+    - cron: '0 3 * * *'  # 3am UTC daily
+
+jobs:
+  stress:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install project dependencies
+        run: uv sync --group dev
+
+      - name: Run stress test in podman
+        run: |
+          podman run --rm \
+            --systemd=always \
+            -v ${{ github.workspace }}:/workspace:z \
+            -w /workspace \
+            python:3.12 \
+            bash -c "pip install uv && uv sync --group dev && uv run pytest test/core/test_background.py::test_background_process_raises_if_dies_unexpectedly --count=100 -v"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "ruff>=0.15.0",
     "mypy>=1.19.1",
     "pytest>=8.0",
+    "pytest-repeat>=0.9.3",
     "types-pyyaml>=6.0.12.20260518",
 ]
 

--- a/src/lambkin/core/process/background.py
+++ b/src/lambkin/core/process/background.py
@@ -134,7 +134,11 @@ class BackgroundProcess:
             target=self._monitor_process,
             daemon=True,
         )
-        self._monitor.start()
+        old_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGUSR1})
+        try:
+            self._monitor.start()
+        finally:
+            signal.pthread_sigmask(signal.SIG_SETMASK, old_mask)
         return self
 
     def __exit__(
@@ -171,7 +175,10 @@ class BackgroundProcess:
         remove_cgroup(self._cgroup)
 
         assert self._proc is not None
-        if exc_type is None and self._died_unexpectedly:
+        if self._died_unexpectedly and exc_type in (
+            None,
+            exceptions.LambkinSIGUSR1Interrupt,
+        ):
             returncode = self._proc.poll()
             raise exceptions.LambkinProcessDiedUnexpectedlyError(
                 self._argv, returncode or 1

--- a/test/core/test_background.py
+++ b/test/core/test_background.py
@@ -138,7 +138,8 @@ def test_background_process_cgroup_removed_on_exit(tmp_path):
     assert not child_cgroup.exists()
 
 
-def test_background_process_raises_if_dies_unexpectedly(tmp_path):
+@pytest.mark.parametrize("duration", ["0", "0.05"])
+def test_background_process_raises_if_dies_unexpectedly(tmp_path, duration):
     """LambkinProcessDiedUnexpectedlyError is raised if process dies before __exit__."""
     iteration_dir = tmp_path / "var_1" / "iter_1"
     iteration_dir.mkdir(parents=True)
@@ -148,7 +149,7 @@ def test_background_process_raises_if_dies_unexpectedly(tmp_path):
 
     shell = ShellProxy(dry_run=False, cwd=tmp_path, cgroup=cgroup)
     with pytest.raises(LambkinProcessDiedUnexpectedlyError):
-        with background(shell.sleep, "0"):
+        with background(shell.sleep, duration):
             shell.python3("-c", COOPERATIVE)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -447,6 +447,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-repeat" },
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
@@ -462,6 +463,7 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-repeat", specifier = ">=0.9.3" },
     { name = "ruff", specifier = ">=0.15.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
 ]
@@ -1390,6 +1392,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-repeat"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/d4/69e9dbb9b8266df0b157c72be32083403c412990af15c7c15f7a3fd1b142/pytest_repeat-0.9.4.tar.gz", hash = "sha256:d92ac14dfaa6ffcfe6917e5d16f0c9bc82380c135b03c2a5f412d2637f224485", size = 6488, upload-time = "2025-04-07T14:59:53.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/d4/8b706b81b07b43081bd68a2c0359fe895b74bf664b20aca8005d2bb3be71/pytest_repeat-0.9.4-py3-none-any.whl", hash = "sha256:c1738b4e412a6f3b3b9e0b8b29fcd7a423e50f87381ad9307ef6f5a8601139f3", size = 4180, upload-time = "2025-04-07T14:59:51.492Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Proposed changes

Fixes a flaky test (`test_background_process_raises_if_dies_unexpectedly`) caused by a race condition in `BackgroundProcess`.
The design assumes `SIGUSR1` arrives while the main thread is blocked in` proc.wait() `inside `CommandProxy.__call__`. However, `sleep 0` can terminate fast enough that the monitor thread sends `SIGUSR1` before` __enter__` has returned — specifically during` threading.Event.wait()` inside `self._monitor.start()`, or during `open()` inside `open_streams`. In those cases `LambkinSIGUSR1Interrupt` escapes `__enter__ `directly,` __exit__` is never called, and the expected `LambkinProcessDiedUnexpectedlyError` is never raised.

Two fixes:

* `__enter__`: block `SIGUSR1` with `pthread_sigmask` while `self._monitor.start()` completes. Once the mask is restored, any pending signal is delivered,  but at that point the with block is active and `__call__` is ready to catch it.
* `__exit__`: accept `LambkinSIGUSR1Interrupt` as a valid `exc_type` alongside `None` when `died_unexpectedly` is set. This covers the remaining timing window where the signal arrives after` __enter__ `returns but before` __call__ `enters its try.

### How to test
```bash
for i in $(seq 100); do
    pytest test/core/test_background.py::test_background_process_raises_if_dies_unexpectedly -v \
    && echo "PASS $i" || { echo "FAIL $i"; break; }
done
```

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments

The root cause was confirmed via `debug` instrumentation: the signal frame pointed to `threading.py:369 `in wait and `proxy.py` in `__call__` in different runs, confirming multiple timing windows. Both are now closed.
