### PR TITLE
Phase 5: Bundle reference dataset for Beluga example as a Docker image

### DIFF
--- a/examples/beluga/README.md
+++ b/examples/beluga/README.md
@@ -23,11 +23,11 @@ The launch file accepts the map path, sensor model type, and particle count as p
   `podman-compose` (see note below)
 - The following reference files available on the host:
 
-| Artifact | Description |
-|---|---|
-| Rosbag | Reference sensor data to replay during the benchmark |
-| Map | Static map file in `.yaml` and `.pgm` format |
-| Groundtruth | Reference trajectory in `.tum` format to evaluate against |
+| Artifact | Default location in image | Description |
+| --- | --- | --- |
+| Rosbag | `/data/datasets/input/` | Reference sensor data to replay during the benchmark. Already includes the ground-truth trajectory topic |
+| Map | `/data/maps/map.yaml` | Static map file in `.yaml` and `.pgm` format |
+| Groundtruth | `/data/ground_truth/ground_truth.tum` | Reference trajectory in `.tum` format, provided for convenience if you'd rather use it directly (e.g. `evo_traj tum`) than use it from the rosbag |
 
 > [!NOTE]
 > `podman-compose` installed via `apt` may be version 1.0.6, which does not support `--profile`. Install a recent version via `pipx`:
@@ -42,16 +42,23 @@ The launch file accepts the map path, sensor model type, and particle count as p
 
 If you are running the benchmark as-is, use the Production profile. If you are modifying the benchmark script or the ROS 2 package, use the Development profile.
 
-### **1. Configure volume mounts**
+### **(Optional) Use your own data**
+
+By default, no volume mounts are needed — the example uses the rosbag, map, and groundtruth baked into the image. To benchmark your own data instead, edit the compose file ([docker-compose.yml](docker/docker-compose.yml) or [podman-compose.yml](docker/podman-compose.yml)) and uncomment the input volume mounts, pointing them at your files:
 
 Edit `docker/docker-compose.yml` and set the host paths to your reference files:
 
 ```yaml
 volumes:
-  - /path/to/your/rosbag:/data/rosbag
-  - /path/to/your/map:/data/map
-  - /path/to/your/groundtruth:/data/groundtruth
+  # ── Inputs (uncomment and adjust paths as needed) ─────────
+  - path/to/your/datasets:/data/datasets:ro
+  - path/to/your//maps:/data/maps:ro
+  - path/to/your//ground_truth:/data/ground_truth:ro
+  # ── Output (benchmark results persisted on host) ──────────
+  - ../results:/ws/examples/beluga/results
 ```
+
+Each mount overrides the corresponding default directory inside `/data/`, so you only need to uncomment the ones you're replacing.
 
 ### **2. Build the image**
 

--- a/examples/beluga/README.md
+++ b/examples/beluga/README.md
@@ -104,7 +104,7 @@ Inside the container:
 
 ```bash
 apt-get update
-rosdep install --from-paths /ws/examples/beluga beluga_ros2 --ignore-src -r -y
+rosdep install --from-paths /ws/examples/beluga/beluga_ros2 --ignore-src -r -y
 uv sync
 uv pip install -e /ws/src/lambkin --system --break-system-packages
 colcon build --base-paths /ws/examples/beluga

--- a/examples/beluga/beluga_benchmark.py
+++ b/examples/beluga/beluga_benchmark.py
@@ -59,25 +59,19 @@ def nominal(ctx):
 @nominal.input
 def dataset(ctx):
     """Return the path to the MCAP dataset used as input for the benchmark."""
-    return ctx.source.path.parent / "rosbags" / "my_bag.mcap"
+    return "/data/datasets/input"
 
 
 @nominal.input
 def map(ctx):
     """Return the path to the map file used for localization."""
-    return ctx.source.path.parent / "maps" / "map.yaml"
-
-
-@nominal.input
-def groundtruth(ctx):
-    """Return the path to the ground truth file used for trajectory evaluation."""
-    return ctx.source.path.parent / "groundtruth" / "groundtruth.txt"
+    return "/data/maps/map.yaml"
 
 
 @nominal.output
 def plots(ctx):
     """Generate and save benchmark plots using aggregated evo_ape results."""
-    lambkin.logger.info(f"output called with ctx: {ctx.paths.base_dir}")
+    lambkin.logger.info(f"output called with ctx: {ctx.base_dir}")
 
 
 if __name__ == "__main__":

--- a/examples/beluga/docker/Dockerfile
+++ b/examples/beluga/docker/Dockerfile
@@ -16,6 +16,9 @@ RUN echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc
 
 # ── Stage 1: development ───────────────────────────────────
 FROM base AS development
+
+COPY --from=ekumenlabs/lambkin-beluga-datasets:jazzy /data/ /data/
+
 CMD ["bash"]
 
 # ── Stage 2: production ────────────────────────────────────

--- a/examples/beluga/docker/docker-compose.yml
+++ b/examples/beluga/docker/docker-compose.yml
@@ -15,9 +15,10 @@ services:
     volumes:
       - ../../..:/ws
       # ── Inputs (uncomment and adjust paths as needed) ─────────
-      # - ../rosbags:/ws/examples/beluga/rosbags:ro
-      # - ../maps:/ws/examples/beluga/maps:ro
-      # - ../groundtruth:/ws/examples/beluga/groundtruth:ro
+      # optionally override datasets:
+      # - ../datasets:/data/datasets:ro
+      # - ../maps:/data/maps:ro
+      # - ../ground_truth:/data/ground_truth:ro
       # ── Output (benchmark results persisted on host) ──────────
       - ../results:/ws/examples/beluga/results
 
@@ -35,8 +36,9 @@ services:
     profiles: ["production"]
     volumes:
       # ── Inputs (uncomment and adjust paths as needed) ─────────
-      # - ../rosbags:/ws/examples/beluga/rosbags:ro
-      # - ../maps:/ws/examples/beluga/maps:ro
-      # - ../groundtruth:/ws/examples/beluga/groundtruth:ro
+      # optionally override datasets:
+      # - ../datasets:/data/datasets:ro
+      # - ../maps:/data/maps:ro
+      # - ../ground_truth:/data/ground_truth:ro
       # ── Output (benchmark results persisted on host) ──────────
       - ../results:/ws/examples/beluga/results


### PR DESCRIPTION
### Proposed changes

The Beluga example currently requires users to manually supply a rosbag, map, and groundtruth trajectory before they can run anything, which gets in the way of using it as a true out-of-the-box CI integration test or a "try it yourself" entry point for new users.

This PR ships a small reference dataset (rosbag, map, groundtruth) baked directly into a dedicated Docker image (`lambkin-beluga-datasets:jazzy`), and updates the Beluga example's Dockerfile to pull that image in and copy its contents to a well-known `/data/` path inside the resulting development/production images. The benchmark script's `@nominal.input` hooks resolve against `/data/` by default, so the example now runs with zero setup.

The datasets image itself was built internally using a throwaway Dockerfile and is not part of this PR. The resulting image will be pushed to Docker Hub.

Users who want to benchmark their own data instead of the bundled defaults can still do so by uncommenting the relevant volume mounts in `docker-compose.yml` / `podman-compose.yml`, which override the corresponding `/data/` subdirectory at runtime without requiring an image rebuild.

This keeps the data and code lifecycles decoupled: the dataset image is built and pushed independently, and the main image just consumes whatever tag is current, so updating the reference dataset doesn't require touching the SDK or example code.

#### How to Test

Production profile (no setup, uses bundled defaults):

```bash
cd examples/beluga/docker
docker compose --profile production build
docker compose --profile production run --rm lambkin_prod bash

# inside the container
uv run lambkin examples/beluga/beluga_benchmark.py
```

Confirm the bundled data is present before running, if you want to double check:

```bash
docker compose --profile production run --rm lambkin_prod ls -R /data
```

Development profile (same check, but also verify the repo volume mount doesn't shadow `/data/`):

```bash
docker compose --profile development build
docker compose --profile development up -d
docker compose --profile development exec lambkin_dev bash

# inside the container
ls /data
```

Override test (confirm custom data takes precedence): uncomment the input volume mounts in `docker-compose.yml`, point them at a different rosbag/map/groundtruth, rebuild, and confirm ls `/data/datasets` etc. reflects the overridden files rather than the bundled defaults.

Podman: repeat the above substituting podman-compose for docker compose, per the README's Podman commands.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 **No Breaking change!**

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments

The datasets image (`lambkin-beluga-datasets`) is intentionally minimal — built `FROM scratch` with no OS layer, just the data files — to keep the pull as cheap as possible. It must already exist as a tag (local or on Docker Hub) before building the Beluga example image, since this PR's Dockerfile references it via `COPY --from=` rather than building it as part of the same build graph.

The bundled rosbag already includes the ground-truth trajectory as a topic; the .tum file under /data/ground_truth/ is provided purely for convenience for users who'd rather use a tool like evo directly on it instead of extracting the trajectory from the bag.

For reference, here is the (throwaway, not committed) Dockerfile used to build and push the datasets image:

```dockerfile
# ── beluga-datasets image ────────────────────────────────────────────────────
#
# A data-only image that ships the Beluga benchmark dataset, ground truth, and
# map.  It has no ROS dependency — just a minimal base so the layer is as small
# as possible and can be pulled cheaply by any platform.
#
# Build:
#   docker build -f Dockerfile.datasets \
#     -t ekumenlabs/lambkin-beluga-datasets:latest \
#     examples/beluga
#
# Push
#   docker push ekumenlabs/lambkin-beluga-datasets:latest
#
# Datasets are stored under /data so the path is stable and predictable for
# downstream consumers (e.g. COPY --from or volume mounts).
# ─────────────────────────────────────────────────────────────────────────────
FROM scratch
 
# Layout mirroring examples/beluga so paths are predictable inside the image:
#   /data/datasets/  ← rosbag (.mcap)
#   /data/maps/      ← occupancy grid (.yaml + .pgm or .png)
#   /data/ground_truth/ ← reference trajectory (.tum)
COPY reference_rosbag/datasets/    /data/datasets/
COPY reference_rosbag/maps/        /data/maps/
COPY reference_rosbag/ground_truth/ /data/ground_truth/
 ```
