### PR TITLE
Phase 5: Fix missing dataset copy in Beluga production Dockerfile stage

### DIFF
--- a/examples/beluga/docker/Dockerfile
+++ b/examples/beluga/docker/Dockerfile
@@ -24,6 +24,8 @@ CMD ["bash"]
 # ── Stage 2: production ────────────────────────────────────
 FROM base AS production
 
+COPY --from=ekumenlabs/lambkin-beluga-datasets:jazzy /data/ /data/
+
 COPY pyproject.toml README.md LICENSE /tmp/lambkin/
 COPY src/ /tmp/lambkin/src/
 RUN uv pip install /tmp/lambkin --system --break-system-packages \


### PR DESCRIPTION
### Proposed changes

Add the missing `COPY --from=ekumenlabs/lambkin-beluga-datasets:jazzy /data/ /data/ `line to the `production` stage of the Beluga example's `Dockerfile`. It was only present in development, so the production image never had the bundled reference dataset, even though the example's own test plan checks ` /data `on both profiles.

How to test

```bash
cd examples/beluga/docker
docker compose --profile production build
docker compose --profile production run --rm lambkin_prod ls -R /data
```

`/data` should now show the bundled `rosbag`, `map`, and `groundtruth`, matching the development profile. Previously this returned an empty/missing `/data`.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

### Additional comments

N/A
