### PR TITLE
Phase 5: Fix podman run command 

### DIFF
--- a/examples/beluga/README.md
+++ b/examples/beluga/README.md
@@ -97,7 +97,7 @@ docker compose --profile development exec lambkin_dev bash
 **Podman**
 
 ```bash
-podman-compose --profile development run --podman-run-args="--systemd=always" --rm lambkin_dev bash
+podman-compose --profile development --podman-run-args=--systemd=always run --rm lambkin_dev bash
 ```
 
 > [!NOTE]
@@ -127,7 +127,7 @@ docker compose --profile production run --rm lambkin_prod bash
 **Podman**
 
 ```bash
-podman-compose --profile production run --podman-run-args="--systemd=always" --rm lambkin_prod bash
+podman-compose --profile production --podman-run-args=--systemd=always run --rm lambkin_prod bash
 ```
 
 > [!WARNING]

--- a/examples/beluga/README.md
+++ b/examples/beluga/README.md
@@ -97,7 +97,7 @@ docker compose --profile development exec lambkin_dev bash
 **Podman**
 
 ```bash
-podman-compose --profile development --podman-run-args=--systemd=always run --rm lambkin_dev bash
+podman-compose --profile development --podman-run-args="--systemd=always" run --rm lambkin_dev bash
 ```
 
 > [!NOTE]
@@ -127,7 +127,7 @@ docker compose --profile production run --rm lambkin_prod bash
 **Podman**
 
 ```bash
-podman-compose --profile production --podman-run-args=--systemd=always run --rm lambkin_prod bash
+podman-compose --profile production --podman-run-args="--systemd=always" run --rm lambkin_prod bash
 ```
 
 > [!WARNING]

--- a/examples/beluga/docker/Dockerfile
+++ b/examples/beluga/docker/Dockerfile
@@ -17,14 +17,14 @@ RUN echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc
 # ── Stage 1: development ───────────────────────────────────
 FROM base AS development
 
-COPY --from=ekumenlabs/lambkin-beluga-datasets:jazzy /data/ /data/
+COPY --from=docker.io/ekumenlabs/lambkin-beluga-datasets:jazzy /data/ /data/
 
 CMD ["bash"]
 
 # ── Stage 2: production ────────────────────────────────────
 FROM base AS production
 
-COPY --from=ekumenlabs/lambkin-beluga-datasets:jazzy /data/ /data/
+COPY --from=docker.io/ekumenlabs/lambkin-beluga-datasets:jazzy /data/ /data/
 
 COPY pyproject.toml README.md LICENSE /tmp/lambkin/
 COPY src/ /tmp/lambkin/src/

--- a/examples/beluga/docker/Dockerfile
+++ b/examples/beluga/docker/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 0: base ─────────────────────────────────────────
-FROM ros:jazzy-ros-base AS base
+FROM docker.io/ros:jazzy-ros-base AS base
 RUN apt-get update && apt-get install -y \
     curl \
     python3-pip \
@@ -29,7 +29,7 @@ COPY --from=ekumenlabs/lambkin-beluga-datasets:jazzy /data/ /data/
 COPY pyproject.toml README.md LICENSE /tmp/lambkin/
 COPY src/ /tmp/lambkin/src/
 RUN uv pip install /tmp/lambkin --system --break-system-packages \
-&& rm -rf /tmp/lambkin
+    && rm -rf /tmp/lambkin
 
 COPY examples/beluga /ws/examples/beluga
 


### PR DESCRIPTION
### Proposed changes

Fix `--podman-run-args` flag position in Podman run commands and update the Dockerfile to use fully qualified image names for Podman compatibility.

#### Fix `--podman-run-args` position

The `--podman-run-args` flag must be placed before the subcommand. Updated both Development and Production Podman commands in the README to move `--podman-run-args="--systemd=always"` before `run`.

#### Fix Dockerfile registry prefix

Update `FROM` lines in the Dockerfile to use fully qualified image names with the `docker.io` registry prefix.

Unlike Docker, Podman does not have Docker Hub as an implicit default registry. Running the following command on a system without `unqualified-search-registries` configured in `/etc/containers/registries.conf` results in:

```
podman-compose --profile development --podman-run-args="--systemd=always" run --rm lambkin_dev bash
[1/2] STEP 1/6: FROM ros:jazzy-ros-base AS base
Error: creating build container: short-name "ros:jazzy-ros-base" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
Error: short-name "lambkin_ros_dev:jazzy" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
```

**Options considered:**

1. **Update `FROM` lines in the Dockerfile** to use fully qualified image names (e.g. `FROM docker.io/ros:jazzy-ros-base`). ✅ Chosen
2. **Build the image with Docker and pull it into Podman** via `podman pull docker-daemon:lambkin_ros_dev:jazzy`. Requires Docker to be installed and running.
3. **Add Docker Hub to `unqualified-search-registries`** in `/etc/containers/registries.conf`. Requires system-level configuration on each machine.

Option 1 is the most portable solution — it requires no extra tooling or system configuration, and no documentation changes are needed.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [x] 📚 Documentation (change which fixes or extends documentation)

💥 No breaking changes

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments

N/A
