### PR TITLE
feat: Add EKF odometry baseline example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,8 @@ build/
 .mypy_cache
 
 # Benchmark inputs/outputs (mounted from docker-compose)
-examples/beluga/results/
+examples/**/results/
+examples/**/datasets/
 examples/beluga/rosbags/
 examples/beluga/maps/
 examples/beluga/groundtruth/

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ def nominal(ctx):
 lambkin/
 ├── src/lambkin/        # The SDK package — see src/lambkin/README.md
 ├── examples/           # Self-contained worked examples
-│   └── beluga/         # Beluga AMCL example
+│   ├── beluga/         # Beluga AMCL example
+│   └── ekf/            # robot_localization EKF odometry baseline
 ├── test/               # Unit and integration tests
 └── pyproject.toml
 ```
@@ -200,3 +201,4 @@ The [`examples/`](examples/) directory contains ready-to-run setups, each packag
 Current examples:
 
 * [examples/beluga/](examples/beluga/README.md) — Beluga AMCL localization, with a worked benchmark script and Docker setup.
+* [examples/ekf/](examples/ekf/README.md) — raw wheel odometry vs. a `robot_localization` EKF fusion, scored with `evo_rpe`.

--- a/examples/ekf/README.md
+++ b/examples/ekf/README.md
@@ -1,0 +1,178 @@
+# EKF Odometry Baseline Example
+
+A worked example of a LAMBKIN benchmark comparing **raw wheel odometry** against an
+**EKF-fused (odometry + IMU) estimate** produced by
+[`robot_localization`](https://github.com/cra-ros-pkg/robot_localization). Unlike the
+[Beluga example](../beluga/README.md), there is no map and no particle filter here — this measures
+how well dead reckoning alone tracks the robot, which is the floor any localization system should
+beat. Ships with its own ROS 2 package and Docker environment.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and
+  [Docker Compose](https://docs.docker.com/compose/) — only needed for
+  [running in a container](#run-in-a-container).
+- Reference data is copied into the image at build time.
+
+| Artifact | Default location in image | Description |
+| --- | --- | --- |
+| Rosbag | `/data/datasets/input/` | Sensor data to replay. Must carry the two topics the EKF fuses (see [Dataset requirements](#dataset-requirements)). |
+| Groundtruth | `/data/ground_truth/groundtruth.tum` | Reference trajectory in `.tum` format, compared against via `evo_rpe`. |
+
+### Dataset requirements
+
+This benchmark is more sensitive to its input than the Beluga one, because the EKF fuses specific
+topics rather than a generic scan. The bag at `/data/datasets/input/` must publish:
+
+| Topic | Type | Used for |
+| --- | --- | --- |
+| `/odom` | `nav_msgs/msg/Odometry` | The `raw_odom` baseline, and the odometry input to the EKF. |
+| `/imu/data_raw_transformed` | `sensor_msgs/msg/Imu` | The EKF's angular-velocity input. |
+| `/clock` | `rosgraph_msgs/msg/Clock` | Sim time source for `ekf_node`. See [Sim time and the recorded `/clock` topic](#sim-time-and-the-recorded-clock-topic). |
+
+The two sensor topic names are configured in
+[`ekf_ros2/params/ekf.ros2.yaml`](ekf_ros2/params/ekf.ros2.yaml) as `odom0` and `imu0` —
+point them at whatever your own recording uses if the names differ.
+
+This example shares its data with the [Beluga example](../beluga/README.md): the bundled
+[`ekumenlabs/lambkin-beluga-datasets`](https://hub.docker.com/r/ekumenlabs/lambkin-beluga-datasets)
+image already carries both topics, so no extra dataset is needed and the benchmark runs out of the
+box. The same 137 s recording drives both examples — Beluga consumes its laser scans, this one its
+wheel odometry and IMU.
+
+To benchmark your own recording instead, point the build at a different data image with the
+`DATASET_IMAGE` build argument:
+
+```bash
+DATASET_IMAGE=my-datasets:latest docker compose --profile development build
+```
+
+Alternatively, leave the image alone and uncomment the input volume mounts in
+[`docker-compose.yml`](docker/docker-compose.yml), which shadow `/data/` at run time.
+
+## How It Works
+
+`nominal()` in [`ekf_benchmark.py`](ekf_benchmark.py) sweeps a single variant parameter,
+`algorithm`, whose two values take completely different paths through the same evaluation:
+
+- **`raw_odom`** — launches nothing at all. It extracts `/odom` straight out of the source bag with
+  `evo_traj`, which is the cheapest possible variant: no ROS system, no playback, no recording.
+- **`ekf_fused`** — launches `ekf_node` in the background, records `/odom_filtered`, plays the bag
+  through the running filter, then extracts the recorded output.
+
+Both branches converge on the same `evo_rpe` call. This is the interesting structural point of the
+example: **a variant parameter does not have to be a tuning knob**. Here it selects between "read a
+topic off disk" and "stand up a ROS node and stream a bag through it", and LAMBKIN sequences,
+isolates, and scores both identically.
+
+### Sim time and the recorded `/clock` topic
+
+`ekf_node` runs with `use_sim_time: true`, taking "now" from the `/clock` topic instead of the wall
+clock — required because the bag's timestamps are years in the past. The bundled dataset already
+records its own `/clock`, so `nominal()` does not pass `--clock` to `ros2.bag.play`.
+
+Passing `--clock` on a bag that already has a recorded `/clock` topic starts a second, independent
+publisher on the same topic. `ekf_node` cannot tell the two apart, and its sim time advances
+erratically as a result — this truncated `/odom_filtered` to ~86 s of the 137 s bag, silently
+dropping 205 of 447 ground-truth poses from the comparison.
+
+If your own recording lacks a `/clock` topic, add `--clock` back to the `ros2.bag.play` call.
+
+### Why RPE instead of APE
+
+The [Beluga example](../beluga/README.md) uses `evo_ape` (Absolute Pose Error). This one uses
+`evo_rpe` (Relative Pose Error) with `--delta 1 --delta_unit m`, measuring error accumulated per
+metre travelled. Open-loop odometry drifts without bound — absolute error would mostly report how
+long the recording is, whereas drift *rate* is comparable across datasets of different lengths.
+
+## How to Run
+
+### Run in a Container
+
+Use the **Production** profile to run as-is, or **Development** to modify the benchmark or the ROS 2
+package.
+
+#### 1. Build the image
+
+```bash
+cd examples/ekf/docker
+docker compose --profile production build
+```
+
+Swap `production` for `development` to build the development image.
+
+#### 2. Start the container
+
+##### Development
+
+Mounts the repository as a volume so code changes are reflected immediately without rebuilding.
+
+```bash
+docker compose --profile development up -d
+docker compose --profile development exec lambkin_dev bash
+```
+
+Inside the container:
+
+```bash
+apt-get update
+rosdep install --from-paths /ws/examples/ekf/ekf_ros2 --ignore-src -r -y
+uv sync
+uv pip install -e /ws --system --break-system-packages
+colcon build --base-paths /ws/examples/ekf
+source install/setup.bash
+```
+
+##### Production
+
+Fully self-contained; no manual steps needed inside the container.
+
+```bash
+docker compose --profile production run --rm lambkin_prod bash
+```
+
+> [!WARNING]
+> Docker runs with `--privileged` to support background process management (cgroup v2 access).
+
+### Run the Benchmark
+
+```bash
+uv run lambkin examples/ekf/ekf_benchmark.py
+```
+
+On top of the [SDK-wide options](../../src/lambkin/README.md#cli), this benchmark registers:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--clock-rate` | `1.0` | Playback rate forwarded to `ros2 bag play -r`. Only affects the `ekf_fused` variant; `raw_odom` never plays the bag. |
+
+## Interpreting the Results
+
+Both variants write `output.rpe.zip`, aggregated by the `stats` and `plots` output hooks into
+per-variant RMSE and a timeseries plot at `results/plots.png`.
+
+> [!WARNING]
+> **Check that both variants cover the same time span before comparing their RMSE.** `evo` matches
+> estimate poses to ground truth within `--t_max_diff` and silently discards anything unmatched, so a
+> trajectory that stops partway through still yields a plausible-looking RMSE over a shorter segment.
+> A `plots.png` where one curve ends earlier than the other is the tell; compare pose counts if in
+> doubt:
+>
+> ```bash
+> wc -l results/var_1/iter_1/odom.tum results/var_2/iter_1/odom_filtered.tum
+> ```
+>
+> See [Sim time and the recorded `/clock` topic](#sim-time-and-the-recorded-clock-topic) for a case
+> where this happens. Set up correctly, both variants match all 447 ground-truth poses (79
+> delta-pairs for `raw_odom`, 77 for `ekf_fused` — small differences here are expected, since
+> `--delta 1m` pairing depends on the exact sampled path).
+
+Do not assume the fused estimate wins. This recording's IMU reports a **constant orientation** with an
+all-zero `orientation_covariance`, so there is no usable absolute heading to fuse — which is why
+[`ekf.ros2.yaml`](ekf_ros2/params/ekf.ros2.yaml) takes only yaw *rate* from the IMU (`imu0_config`)
+and leaves heading to odometry's own dead reckoning. With that little extra information available,
+the filter may well not beat raw odometry, and that is a legitimate result: "add a filter" is a
+hypothesis a benchmark should test rather than assume.
+
+For everything else — listing options, selecting a subset of variants, dry-running, reading results
+back with `lambkin.data` — see the [SDK documentation](../../src/lambkin/README.md).

--- a/examples/ekf/docker/Dockerfile
+++ b/examples/ekf/docker/Dockerfile
@@ -1,0 +1,49 @@
+# Image supplying the reference data at /data/. Override to point at your own
+# recording, e.g.:
+#   docker compose build --build-arg DATASET_IMAGE=my-datasets:latest
+# See ../README.md#dataset-requirements for the topics the bag must carry.
+ARG DATASET_IMAGE=docker.io/ekumenlabs/lambkin-beluga-datasets:jazzy
+
+FROM ${DATASET_IMAGE} AS datasets
+
+# ── Stage 0: base ─────────────────────────────────────────
+FROM docker.io/ros:jazzy-ros-base AS base
+RUN apt-get update && apt-get install -y \
+    curl \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /ws
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/bin" sh
+
+RUN rosdep init || true \
+    && rosdep update
+
+RUN echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc
+
+# ── Stage 1: development ───────────────────────────────────
+FROM base AS development
+
+COPY --from=datasets /data/ /data/
+
+CMD ["bash"]
+
+# ── Stage 2: production ────────────────────────────────────
+FROM base AS production
+
+COPY --from=datasets /data/ /data/
+
+COPY pyproject.toml README.md LICENSE /tmp/lambkin/
+COPY src/ /tmp/lambkin/src/
+RUN uv pip install /tmp/lambkin --system --break-system-packages \
+    && rm -rf /tmp/lambkin
+
+COPY examples/ekf /ws/examples/ekf
+
+RUN apt-get update \
+    && rosdep install --from-paths examples/ekf --ignore-src -y \
+    && rm -rf /var/lib/apt/lists/*
+RUN . /opt/ros/jazzy/setup.sh && colcon build --base-paths examples/ekf
+
+CMD ["bash"]

--- a/examples/ekf/docker/docker-compose.yml
+++ b/examples/ekf/docker/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+
+  lambkin_dev:
+    build:
+      context: ../../..
+      dockerfile: examples/ekf/docker/Dockerfile
+      target: development
+      args:
+        DATASET_IMAGE: ${DATASET_IMAGE:-docker.io/ekumenlabs/lambkin-beluga-datasets:jazzy}
+    image: lambkin_ekf_dev:jazzy
+    container_name: lambkin_ekf_developer
+    network_mode: "host"
+    privileged: true
+    stdin_open: true
+    tty: true
+    profiles: ["development"]
+    volumes:
+      - ../../..:/ws
+      # ── Inputs (uncomment and adjust paths as needed) ─────────
+      # optionally override datasets:
+      # - ../datasets:/data/datasets:ro
+      # - ../ground_truth:/data/ground_truth:ro
+      # ── Output (benchmark results persisted on host) ──────────
+      - ../results:/ws/examples/ekf/results
+
+  lambkin_prod:
+    build:
+      context: ../../..
+      dockerfile: examples/ekf/docker/Dockerfile
+      target: production
+      args:
+        DATASET_IMAGE: ${DATASET_IMAGE:-docker.io/ekumenlabs/lambkin-beluga-datasets:jazzy}
+    image: lambkin_ekf:jazzy
+    container_name: lambkin_ekf_production
+    network_mode: "host"
+    privileged: true
+    stdin_open: true
+    tty: true
+    profiles: ["production"]
+    volumes:
+      # ── Inputs (uncomment and adjust paths as needed) ─────────
+      # optionally override datasets:
+      # - ../datasets:/data/datasets:ro
+      # - ../ground_truth:/data/ground_truth:ro
+      # ── Output (benchmark results persisted on host) ──────────
+      - ../results:/ws/examples/ekf/results

--- a/examples/ekf/ekf_benchmark.py
+++ b/examples/ekf/ekf_benchmark.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Odometry baseline: raw wheel odometry vs. robot_localization EKF fusion."""
+
+import matplotlib.pyplot as plt
+
+import lambkin
+
+
+@lambkin.benchmark(
+    variants=lambkin.common.named_product(algorithm=["raw_odom", "ekf_fused"]),
+    num_iterations=2,
+)
+@lambkin.option("--clock-rate", default=1.0)
+def nominal(ctx):
+    """Evaluate raw wheel odometry against an EKF-fused (odom+IMU) estimate.
+
+    Args:
+        ctx: Lambkin context with variant, options, source, and shell access.
+
+    Raises:
+        ValueError: If ctx.variant.algorithm is not a known algorithm.
+    """
+    lambkin.logger.info(
+        "Running benchmark with variant: %s, iteration: %d", ctx.variant, ctx.iteration
+    )
+
+    match ctx.variant.algorithm:
+        case "raw_odom":
+            ctx.shell.evo_traj.bag2(ctx.inputs.dataset, "/odom", "--save_as_tum")
+            odom_tum = "odom.tum"
+        case "ekf_fused":
+            with lambkin.process.background(
+                ctx.shell.ros2.bag.record,
+                "--output",
+                "output",
+                "--topics",
+                "/odom_filtered",
+            ):
+                with lambkin.process.background(
+                    ctx.shell.ros2.launch,
+                    "ekf_ros2",
+                    "ekf.launch.py",
+                ):
+                    ctx.shell.ros2.bag.play(
+                        ctx.inputs.dataset, "-r", ctx.options.clock_rate
+                    )
+            ctx.shell.evo_traj.bag2("output", "/odom_filtered", "--save_as_tum")
+            odom_tum = "odom_filtered.tum"
+        case unknown:
+            raise ValueError(
+                f"Unknown algorithm {unknown!r}: expected 'raw_odom' or 'ekf_fused'."
+            )
+
+    ctx.shell.evo_rpe.tum(
+        ctx.inputs.ground_truth,
+        odom_tum,
+        "--t_max_diff",
+        "0.5",
+        "--delta",
+        "1",
+        "--delta_unit",
+        "m",
+        "--save_results",
+        "output.rpe.zip",
+    )
+
+
+@nominal.input
+def dataset(ctx):
+    """Return the path to the MCAP dataset used as input for the benchmark."""
+    return "/data/datasets/input"
+
+
+@nominal.input
+def ground_truth(ctx):
+    """Return the path to the TUM ground-truth trajectory file."""
+    return "/data/ground_truth/groundtruth.tum"
+
+
+@nominal.output
+def plots(ctx):
+    """Save RPE timeseries plot for all iterations, one line per variant."""
+    for entry in lambkin.data.evo.series(ctx, "output.rpe.zip"):
+        plt.plot(
+            entry.time, entry.error, label=f"{entry.variant} / iter {entry.iteration}"
+        )
+    plt.xlabel("Time (s)")
+    plt.ylabel("Error (m)")
+    plt.legend()
+    plt.savefig(ctx.base_dir / "plots.png")
+
+
+@nominal.output
+def stats(ctx):
+    """Log RMSE, mean, and max RPE for all iterations."""
+    for entry in lambkin.data.evo.stats(ctx, "output.rpe.zip"):
+        lambkin.logger.info(
+            "%s iter %d: rmse=%.4f mean=%.4f max=%.4f",
+            entry.variant,
+            entry.iteration,
+            entry.rmse,
+            entry.mean,
+            entry.max,
+        )
+
+
+if __name__ == "__main__":
+    nominal()

--- a/examples/ekf/ekf_ros2/CMakeLists.txt
+++ b/examples/ekf/ekf_ros2/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.16)
+project(ekf_ros2)
+find_package(ament_cmake REQUIRED)
+find_package(robot_localization REQUIRED)
+
+install(
+  DIRECTORY
+    launch
+    params
+  DESTINATION share/${PROJECT_NAME})
+
+ament_export_dependencies(
+  launch
+  launch_ros
+)
+ament_package()

--- a/examples/ekf/ekf_ros2/launch/ekf.launch.py
+++ b/examples/ekf/ekf_ros2/launch/ekf.launch.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Ekumen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch file for the robot_localization EKF odometry baseline.
+
+Launches robot_localization's ekf_node alone (no map, no lifecycle
+manager) fusing wheel odometry and IMU data to produce a filtered
+odometry estimate, for comparison against the raw /odom baseline.
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+pkg_dir = get_package_share_directory("ekf_ros2")
+
+default_yaml_path = os.path.join(pkg_dir, "params", "ekf.ros2.yaml")
+
+
+def generate_launch_description():
+    """Generate the launch description for the EKF odometry baseline.
+
+    Declares a params_file launch argument and configures
+    robot_localization's ekf_node, remapping its default output topic to
+    a flat name so it can be evaluated the same way as other pose topics
+    in this project.
+
+    Returns:
+        LaunchDescription: The complete ROS 2 launch description object.
+    """
+    params_file_arg = DeclareLaunchArgument(
+        "params_file",
+        default_value=default_yaml_path,
+        description="Absolute YAML file path",
+    )
+
+    ekf_node = Node(
+        package="robot_localization",
+        executable="ekf_node",
+        name="ekf_filter_node",
+        output="screen",
+        parameters=[LaunchConfiguration("params_file")],
+        remappings=[("odometry/filtered", "odom_filtered")],
+    )
+
+    return LaunchDescription([
+        params_file_arg,
+        ekf_node,
+    ])

--- a/examples/ekf/ekf_ros2/package.xml
+++ b/examples/ekf/ekf_ros2/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ekf_ros2</name>
+  <version>1.0.0</version>
+  <description>ROS2 launch for the EKF odometry baseline</description>
+
+  <maintainer email="daffer.queque@gmail.com">Daffer Queque</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>robot_localization</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/examples/ekf/ekf_ros2/params/ekf.ros2.yaml
+++ b/examples/ekf/ekf_ros2/params/ekf.ros2.yaml
@@ -1,0 +1,50 @@
+ekf_filter_node:
+  ros__parameters:
+    # Use the /clock topic recorded in the source bag instead of the wall
+    # clock, since the recording's timestamps are years in the past.
+    use_sim_time: true
+    # Rate, in Hz, at which the filter publishes its state estimate. Under
+    # use_sim_time this is a ceiling: actual rate is capped by how fast
+    # /clock advances (~40 Hz for the bundled dataset).
+    frequency: 50.0
+    # Assume the robot only moves in the horizontal plane.
+    two_d_mode: true
+    # Do not broadcast odom->base_link; the source bag's own recorded /tf
+    # is used for playback instead.
+    publish_tf: false
+    # The frame used as the parent for the filter's estimated pose.
+    map_frame: map
+    # The frame published by the odometry system being fused.
+    odom_frame: odom
+    # The frame of the robot base.
+    base_link_frame: base_footprint
+    # The frame in which the filter's output is expressed.
+    world_frame: odom
+
+    # Wheel odometry input topic.
+    odom0: /odom
+    # Fuse yaw and linear/angular velocity from odometry. Yaw comes from
+    # odom rather than the IMU because the IMU's orientation field is an
+    # unusable placeholder (see imu0_config below).
+    odom0_config: [false, false, false,
+                   false, false, true,
+                   true,  true,  false,
+                   false, false, true,
+                   false, false, false]
+    odom0_differential: false
+    odom0_relative: false
+    odom0_queue_size: 10
+
+    # IMU input topic.
+    imu0: /imu/data_raw_transformed
+    # Fuse only yaw rate: this IMU's orientation field is a constant
+    # placeholder with zero covariance, so fusing absolute roll/pitch/yaw
+    # would anchor heading to a bogus fixed value.
+    imu0_config: [false, false, false,
+                  false, false, false,
+                  false, false, false,
+                  false, false, true,
+                  false, false, false]
+    imu0_differential: false
+    imu0_relative: false
+    imu0_queue_size: 10


### PR DESCRIPTION
### Proposed changes

Adds `examples/ekf/`, a new worked example alongside `examples/beluga/`. It sweeps a single `algorithm` variant (`raw_odom` vs `ekf_fused`) to compare open-loop wheel odometry against a `robot_localization` EKF fusion, scored with `evo_rpe` (drift-rate, since open-loop odometry drifts unboundedly). Ships its own ROS 2 package and Docker/Docker Compose environment, reusing the same bundled dataset image as Beluga.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)1

💥 **Breaking change!** _Explain why a non-backwards compatible change is necessary or remove this line entirely if not applicable._

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### Additional comments

- No automated tests, same as `examples/beluga/` — validated by running the benchmark end-to-end in the dev container.
- Docker only; Podman support left out since it wasn't verified.
- Worth flagging for review: `nominal()` deliberately skips `--clock` on `ros2 bag play`, since the dataset already carries its own recorded `/clock` topic. Passing it too starts a conflicting second publisher that corrupts `ekf_node`'s sim time and silently truncates the trajectory — see the README's "Sim time and the recorded `/clock` topic" section.